### PR TITLE
Add Google OAuth sign-in integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=10080
 
 # API Configuration
 API_URL=http://localhost:8000
+
+# Google OAuth 2.0 (Get from: https://console.cloud.google.com/apis/credentials)
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,5 +20,9 @@ ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 
 # ── Google Places API ───────────────────────────────────────────────
 GOOGLE_API_KEY: str = os.getenv("GOOGLE_API_KEY", "")
 
+# ── Google OAuth ────────────────────────────────────────────────────
+GOOGLE_CLIENT_ID: str = os.getenv("GOOGLE_CLIENT_ID", "")
+GOOGLE_CLIENT_SECRET: str = os.getenv("GOOGLE_CLIENT_SECRET", "")
+
 # ── API ─────────────────────────────────────────────────────────────
 API_URL: str = os.getenv("API_URL", "http://localhost:8000")

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -9,8 +9,11 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, status, Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
+from google.oauth2 import id_token
+from google.auth.transport import requests
+from pydantic import BaseModel
 
-from config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES
+from config import SECRET_KEY, ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES, GOOGLE_CLIENT_ID
 from models.user import UserCreate, UserLogin, User, Token, TokenData
 from database.mongodb import get_users_collection
 
@@ -19,6 +22,12 @@ security = HTTPBearer()
 
 # Router
 router = APIRouter()
+
+
+# Request Models
+class GoogleAuthRequest(BaseModel):
+    """Request model for Google authentication"""
+    credential: str  # Google ID token
 
 
 # Helper Functions
@@ -188,3 +197,72 @@ async def get_current_user_info(current_user: User = Depends(get_current_user)):
     Requires valid JWT token
     """
     return current_user
+
+
+@router.post("/google", response_model=Token)
+async def google_auth(auth_request: GoogleAuthRequest):
+    """
+    Authenticate user with Google OAuth
+    - Verifies Google ID token
+    - Creates or updates user account
+    - Returns JWT access token
+    """
+    try:
+        users_collection = get_users_collection()
+    except Exception as db_error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Database unavailable: {str(db_error)}"
+        )
+    
+    # Verify the Google token
+    try:
+        idinfo = id_token.verify_oauth2_token(
+            auth_request.credential, 
+            requests.Request(), 
+            GOOGLE_CLIENT_ID
+        )
+        
+        # Extract user information from Google token
+        google_id = idinfo['sub']
+        email = idinfo['email']
+        name = idinfo.get('name', email.split('@')[0])
+        
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid Google token: {str(e)}"
+        )
+    
+    # Check if user already exists
+    user = await users_collection.find_one({"email": email})
+    
+    if user:
+        # Update existing user's Google ID if not set
+        if "google_id" not in user or user["google_id"] != google_id:
+            await users_collection.update_one(
+                {"email": email},
+                {"$set": {"google_id": google_id, "updated_at": datetime.utcnow()}}
+            )
+        user_id = str(user["_id"])
+    else:
+        # Create new user
+        user_dict = {
+            "name": name,
+            "email": email,
+            "google_id": google_id,
+            "role": "customer",
+            "favorites": [],
+            "created_at": datetime.utcnow(),
+            "auth_provider": "google"
+        }
+        
+        result = await users_collection.insert_one(user_dict)
+        user_id = str(result.inserted_id)
+    
+    # Create access token
+    access_token = create_access_token(
+        data={"sub": email, "user_id": user_id}
+    )
+    
+    return Token(access_token=access_token, token_type="bearer")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -33,6 +33,8 @@ class User(UserBase):
     """User schema returned to client (without sensitive data)"""
     id: str
     favorites: List[str] = Field(default_factory=list)
+    google_id: Optional[str] = None
+    auth_provider: Optional[str] = None
     
     class Config:
         from_attributes = True
@@ -40,7 +42,7 @@ class User(UserBase):
 
 class UserInDB(User):
     """User schema as stored in database (includes password hash)"""
-    hashed_password: str
+    hashed_password: Optional[str] = None  # Optional for OAuth users
 
 
 class UserLogin(BaseModel):

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Google OAuth 2.0 Configuration
+# Get your Google Client ID from: https://console.cloud.google.com/apis/credentials
+# Make sure to add http://localhost:5173 to Authorized JavaScript origins
+VITE_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@react-oauth/google": "^0.13.4",
         "@supabase/supabase-js": "^2.90.1",
         "@tailwindcss/postcss": "^4.1.18",
         "autoprefixer": "^10.4.23",
@@ -1892,6 +1893,16 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.4.tgz",
+      "integrity": "sha512-hGKyNEH+/PK8M0sFEuo3MAEk0txtHpgs94tDQit+s2LXg7b6z53NtzHfqDvoB2X8O6lGB+FRg80hY//X6hfD+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@react-oauth/google": "^0.13.4",
     "@supabase/supabase-js": "^2.90.1",
     "@tailwindcss/postcss": "^4.1.18",
     "autoprefixer": "^10.4.23",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -47,6 +47,19 @@ export const api = {
     return response.json();
   },
 
+  async googleAuth(credential: string): Promise<AuthTokens> {
+    const response = await fetch(`${API_URL}/auth/google`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credential }),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.detail || 'Google authentication failed');
+    }
+    return response.json();
+  },
+
   // ─── Businesses ──────────────────────────────
   async getBusinesses(category?: string, sortBy?: string, search?: string): Promise<Business[]> {
     const params = new URLSearchParams();

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ interface AuthContextType {
   loading: boolean;
   signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (name: string, email: string, password: string, role: string) => Promise<{ error: string | null }>;
+  signInWithGoogle: (credential: string) => Promise<{ error: string | null }>;
   signOut: () => void;
   isAuthenticated: boolean;
 }
@@ -17,6 +18,7 @@ const AuthContext = createContext<AuthContextType>({
   loading: true,
   signIn: async () => ({ error: null }),
   signUp: async () => ({ error: null }),
+  signInWithGoogle: async () => ({ error: null }),
   signOut: () => {},
   isAuthenticated: false,
 });
@@ -78,6 +80,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const signInWithGoogle = async (credential: string) => {
+    try {
+      const tokens = await api.googleAuth(credential);
+      localStorage.setItem('vantage_token', tokens.access_token);
+      await fetchUser();
+      return { error: null };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : 'Google sign-in failed' };
+    }
+  };
+
   const signOut = () => {
     localStorage.removeItem('vantage_token');
     setUser(null);
@@ -90,6 +103,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         loading,
         signIn,
         signUp,
+        signInWithGoogle,
         signOut,
         isAuthenticated: !!user,
       }}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { GoogleOAuthProvider } from '@react-oauth/google'
 import { AuthProvider } from './contexts/AuthContext'
 import RootLayout from './layout'
 import HomePage from './page'
@@ -14,24 +15,28 @@ import DashboardPage from './pages/DashboardPage'
 import ClaimBusinessPage from './pages/ClaimBusinessPage'
 import './index.css'
 
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <RootLayout>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/businesses" element={<Businesses />} />
-            <Route path="/activity" element={<ActivityFeedPage />} />
-            <Route path="/pricing" element={<PricingPage />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/claim" element={<ClaimBusinessPage />} />
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/signup" element={<SignUpPage />} />
-            <Route path="/account" element={<AccountPage />} />
-          </Routes>
-        </RootLayout>
-      </AuthProvider>
-    </BrowserRouter>
+    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+      <BrowserRouter>
+        <AuthProvider>
+          <RootLayout>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/businesses" element={<Businesses />} />
+              <Route path="/activity" element={<ActivityFeedPage />} />
+              <Route path="/pricing" element={<PricingPage />} />
+              <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/claim" element={<ClaimBusinessPage />} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/signup" element={<SignUpPage />} />
+              <Route path="/account" element={<AccountPage />} />
+            </Routes>
+          </RootLayout>
+        </AuthProvider>
+      </BrowserRouter>
+    </GoogleOAuthProvider>
   </StrictMode>,
 )

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { GoogleLogin } from '@react-oauth/google';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -8,7 +9,7 @@ import { useAuth } from '@/contexts/AuthContext';
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { signIn, isAuthenticated } = useAuth();
+  const { signIn, signInWithGoogle, isAuthenticated } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -36,11 +37,34 @@ export default function LoginPage() {
     }
   };
 
+  const handleGoogleSuccess = async (credentialResponse: { credential?: string }) => {
+    if (!credentialResponse.credential) {
+      setError('Google sign-in failed. Please try again.');
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+
+    const { error: err } = await signInWithGoogle(credentialResponse.credential);
+
+    if (err) {
+      setError(err);
+      setLoading(false);
+    } else {
+      navigate('/businesses');
+    }
+  };
+
+  const handleGoogleError = () => {
+    setError('Google sign-in failed. Please try again.');
+  };
+
   return (
     <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4 gradient-mesh">
       {/* Decorative blobs */}
-<div className="absolute top-32 left-10 w-72 h-72 bg-brand-light/10 rounded-full blur-3xl animate-float" />
-        <div className="absolute bottom-10 right-10 w-72 h-72 bg-brand-light/10 rounded-full blur-3xl animate-float animation-delay-2000" />
+      <div className="absolute top-32 left-10 w-72 h-72 bg-brand-light/10 rounded-full blur-3xl animate-float" />
+      <div className="absolute bottom-10 right-10 w-72 h-72 bg-brand-light/10 rounded-full blur-3xl animate-float animation-delay-2000" />
 
       <div className="w-full max-w-md relative animate-fade-in-up">
         <div className="glass-card rounded-2xl p-8 shadow-xl">
@@ -114,6 +138,27 @@ export default function LoginPage() {
               )}
             </Button>
           </form>
+
+          {/* Divider */}
+          <div className="flex items-center gap-4 my-6">
+            <div className="flex-1 h-px bg-[hsl(var(--border))]"></div>
+            <span className="text-ui text-[hsl(var(--muted-foreground))]">or</span>
+            <div className="flex-1 h-px bg-[hsl(var(--border))]"></div>
+          </div>
+
+          {/* Google Sign In */}
+          <div className="flex justify-center">
+            <GoogleLogin
+              onSuccess={handleGoogleSuccess}
+              onError={handleGoogleError}
+              useOneTap
+              theme="outline"
+              size="large"
+              text="signin_with"
+              shape="rectangular"
+              width="100%"
+            />
+          </div>
 
           {/* Sign Up Link */}
           <div className="mt-6 text-center">

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { GoogleLogin } from '@react-oauth/google';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -9,7 +10,7 @@ import { cn } from '@/lib/utils';
 
 export default function SignUpPage() {
   const navigate = useNavigate();
-  const { signUp, isAuthenticated } = useAuth();
+  const { signUp, signInWithGoogle, isAuthenticated } = useAuth();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -46,6 +47,29 @@ export default function SignUpPage() {
     } else {
       navigate('/businesses');
     }
+  };
+
+  const handleGoogleSuccess = async (credentialResponse: { credential?: string }) => {
+    if (!credentialResponse.credential) {
+      setError('Google sign-in failed. Please try again.');
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+
+    const { error: err } = await signInWithGoogle(credentialResponse.credential);
+
+    if (err) {
+      setError(err);
+      setLoading(false);
+    } else {
+      navigate('/businesses');
+    }
+  };
+
+  const handleGoogleError = () => {
+    setError('Google sign-in failed. Please try again.');
   };
 
   return (
@@ -166,6 +190,26 @@ export default function SignUpPage() {
               )}
             </Button>
           </form>
+
+          {/* Divider */}
+          <div className="flex items-center gap-4 my-6">
+            <div className="flex-1 h-px bg-[hsl(var(--border))]"></div>
+            <span className="text-ui text-[hsl(var(--muted-foreground))]">or</span>
+            <div className="flex-1 h-px bg-[hsl(var(--border))]"></div>
+          </div>
+
+          {/* Google Sign In */}
+          <div className="flex justify-center">
+            <GoogleLogin
+              onSuccess={handleGoogleSuccess}
+              onError={handleGoogleError}
+              theme="outline"
+              size="large"
+              text="signup_with"
+              shape="rectangular"
+              width="100%"
+            />
+          </div>
 
           <div className="mt-6 text-center">
             <p className="text-ui text-[hsl(var(--muted-foreground))]">


### PR DESCRIPTION
Integrate Google OAuth for sign-in/sign-up across backend and frontend.

Backend: add GOOGLE_CLIENT_ID/SECRET to .env.example and config; implement /auth/google endpoint that verifies Google ID tokens (google.oauth2.id_token), creates or updates users (stores google_id and auth_provider), and returns JWTs. Make stored password optional for OAuth users and add google_id/auth_provider to User schema. Add DB availability and token verification error handling.

Frontend: add @react-oauth/google dependency and new VITE_GOOGLE_CLIENT_ID .env.example; wrap app with GoogleOAuthProvider, add GoogleLogin buttons to Login and SignUp pages, implement api.googleAuth, and expose signInWithGoogle in AuthContext to exchange Google credential for app tokens and fetch user state.