### PR TITLE
Replace default favicon and add Apple touch icon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/Images/vantage.png" />
+    <link rel="apple-touch-icon" href="/Images/vantage.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Swap the template Vite favicon (vite.svg) for the project PNG at /Images/vantage.png and add an Apple touch icon for iOS devices. Updates the <link rel="icon"> and introduces <link rel="apple-touch-icon"> to ensure proper icons across platforms.