### PR TITLE
Add Dependabot config for frontend and backend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Enable version updates for npm (frontend)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Crackle2K"
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  # Enable version updates for pip (backend)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "Crackle2K"
+    labels:
+      - "dependencies"
+      - "backend"


### PR DESCRIPTION
Add .github/dependabot.yml (version 2) to enable automated dependency updates: weekly npm updates in /frontend and weekly pip updates in /backend. Limits open PRs to 10, assigns reviewer Crackle2K, and tags PRs with appropriate labels (dependencies, frontend/backend). This automates dependency maintenance and helps keep packages up-to-date for security and bug fixes.