### PR TITLE
Add CI lint workflow and TS type-check script

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  push:
+    branches: [ main, develop ]
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 black isort mypy
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Lint Python with flake8
+        run: |
+          flake8 backend --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 backend --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Check Python formatting with black
+        run: black --check backend
+
+      - name: Check Python imports with isort
+        run: isort --check-only backend
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Lint frontend with ESLint
+        working-directory: ./frontend
+        run: npm run lint --if-present
+
+      - name: Type check frontend
+        working-directory: ./frontend
+        run: npm run type-check --if-present

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "type-check": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
Add a GitHub Actions workflow (.github/workflows/lint.yml) to run linting and type checks on push and pull_request to main and develop. The job sets up Python 3.11 and Node 20, installs Python tools (flake8, black, isort, mypy), runs flake8/black/isort against the backend, installs frontend dependencies with npm ci, runs ESLint, and runs the frontend type check if present. Also add a frontend/package.json script "type-check": "tsc --noEmit" so the workflow can execute TypeScript type checking.