### PR TITLE
Add liking and commenting to activity feed

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -40,6 +40,7 @@ app.add_middleware(
         "http://localhost:3000",
         "http://localhost:5174",
     ],
+    allow_origin_regex=r"https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/routes/activity.py
+++ b/backend/routes/activity.py
@@ -17,6 +17,7 @@ from typing import List, Optional
 from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException, status, Depends, Query
 from bson import ObjectId
+from pydantic import BaseModel, Field
 
 from models.activity import (
     CheckInCreate,
@@ -36,6 +37,18 @@ from database.mongodb import (
 )
 
 router = APIRouter()
+
+
+class ActivityCommentCreate(BaseModel):
+    content: str = Field(..., min_length=1, max_length=500)
+
+
+class ActivityComment(BaseModel):
+    id: str
+    user_id: str
+    user_name: str
+    content: str
+    created_at: datetime
 
 
 def checkin_helper(doc) -> dict:
@@ -264,6 +277,125 @@ async def get_activity_feed(
         "page": page,
         "page_size": page_size,
         "has_more": skip + page_size < total,
+    }
+
+
+@router.post("/feed/{activity_id}/like")
+async def toggle_activity_like(
+    activity_id: str,
+    current_user: User = Depends(get_current_user),
+):
+    """Toggle like on an activity feed item for the current user."""
+    activity_feed = get_activity_feed_collection()
+
+    if not ObjectId.is_valid(activity_id):
+        raise HTTPException(status_code=400, detail="Invalid activity ID")
+
+    target_id = ObjectId(activity_id)
+
+    unlike_result = await activity_feed.update_one(
+        {"_id": target_id, "liked_by": current_user.id},
+        {
+            "$pull": {"liked_by": current_user.id},
+            "$inc": {"likes": -1},
+        },
+    )
+
+    liked = False
+    if unlike_result.matched_count == 0:
+        like_result = await activity_feed.update_one(
+            {"_id": target_id, "liked_by": {"$ne": current_user.id}},
+            {
+                "$addToSet": {"liked_by": current_user.id},
+                "$inc": {"likes": 1},
+            },
+        )
+        if like_result.matched_count == 0:
+            raise HTTPException(status_code=404, detail="Activity item not found")
+        liked = True
+
+    item = await activity_feed.find_one({"_id": target_id})
+    if not item:
+        raise HTTPException(status_code=404, detail="Activity item not found")
+
+    likes_count = max(0, int(item.get("likes", 0)))
+    if likes_count != item.get("likes", 0):
+        await activity_feed.update_one({"_id": target_id}, {"$set": {"likes": likes_count}})
+
+    return {
+        "liked": liked,
+        "likes": likes_count,
+        "comments": int(item.get("comments", 0)),
+    }
+
+
+@router.get("/feed/{activity_id}/comments", response_model=List[ActivityComment])
+async def get_activity_comments(activity_id: str):
+    """Fetch comments for a specific activity feed item."""
+    activity_feed = get_activity_feed_collection()
+
+    if not ObjectId.is_valid(activity_id):
+        raise HTTPException(status_code=400, detail="Invalid activity ID")
+
+    item = await activity_feed.find_one(
+        {"_id": ObjectId(activity_id)},
+        {"comments_list": 1},
+    )
+    if not item:
+        raise HTTPException(status_code=404, detail="Activity item not found")
+
+    comments = item.get("comments_list", [])
+    comments_sorted = sorted(comments, key=lambda c: c.get("created_at", datetime.min))
+    return [
+        ActivityComment(
+            id=str(comment.get("id") or ""),
+            user_id=comment.get("user_id", ""),
+            user_name=comment.get("user_name", "Anonymous"),
+            content=comment.get("content", ""),
+            created_at=comment.get("created_at", datetime.utcnow()),
+        )
+        for comment in comments_sorted
+    ]
+
+
+@router.post("/feed/{activity_id}/comments", status_code=status.HTTP_201_CREATED)
+async def add_activity_comment(
+    activity_id: str,
+    payload: ActivityCommentCreate,
+    current_user: User = Depends(get_current_user),
+):
+    """Add a comment to an activity feed item."""
+    activity_feed = get_activity_feed_collection()
+
+    if not ObjectId.is_valid(activity_id):
+        raise HTTPException(status_code=400, detail="Invalid activity ID")
+
+    target_id = ObjectId(activity_id)
+    comment_doc = {
+        "id": str(ObjectId()),
+        "user_id": current_user.id,
+        "user_name": current_user.name,
+        "content": payload.content.strip(),
+        "created_at": datetime.utcnow(),
+    }
+
+    if not comment_doc["content"]:
+        raise HTTPException(status_code=400, detail="Comment cannot be empty")
+
+    result = await activity_feed.update_one(
+        {"_id": target_id},
+        {
+            "$push": {"comments_list": comment_doc},
+            "$inc": {"comments": 1},
+        },
+    )
+    if result.matched_count == 0:
+        raise HTTPException(status_code=404, detail="Activity item not found")
+
+    item = await activity_feed.find_one({"_id": target_id}, {"comments": 1})
+    return {
+        "comment": comment_doc,
+        "comments": int(item.get("comments", 0)) if item else 0,
     }
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,6 +86,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2676,6 +2677,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2686,6 +2688,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2744,6 +2747,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2995,6 +2999,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3146,6 +3151,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3426,6 +3432,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4422,6 +4429,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4448,6 +4456,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4488,6 +4497,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4497,6 +4507,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4840,6 +4851,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4967,6 +4979,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5109,6 +5122,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Business, Review, Deal, ReviewCreate, User, AuthTokens, BusinessClaim, ClaimCreate, Subscription, SubscriptionCreate, TierInfo, CheckIn, CheckInCreate, UserCredibility, ActivityFeedItem, BusinessActivityStatus } from './types';
+import type { Business, Review, Deal, ReviewCreate, User, AuthTokens, BusinessClaim, ClaimCreate, Subscription, SubscriptionCreate, TierInfo, CheckIn, CheckInCreate, UserCredibility, ActivityFeedItem, BusinessActivityStatus, ActivityComment, ActivityLikeResult } from './types';
 
 const API_URL = 'http://localhost:8000/api';
 
@@ -219,6 +219,40 @@ export const api = {
       headers: getAuthHeaders(),
     });
     if (!response.ok) throw new Error('Failed to fetch credibility');
+    return response.json();
+  },
+
+  async toggleActivityLike(activityId: string): Promise<ActivityLikeResult> {
+    const response = await fetch(`${API_URL}/feed/${activityId}/like`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.detail || 'Failed to like activity');
+    }
+    return response.json();
+  },
+
+  async getActivityComments(activityId: string): Promise<ActivityComment[]> {
+    const response = await fetch(`${API_URL}/feed/${activityId}/comments`);
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.detail || 'Failed to fetch comments');
+    }
+    return response.json();
+  },
+
+  async addActivityComment(activityId: string, content: string): Promise<{ comment: ActivityComment; comments: number }> {
+    const response = await fetch(`${API_URL}/feed/${activityId}/comments`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: JSON.stringify({ content }),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.detail || 'Failed to add comment');
+    }
     return response.json();
   },
 

--- a/frontend/src/pages/ActivityFeedPage.tsx
+++ b/frontend/src/pages/ActivityFeedPage.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import { api } from '../api'
-import type { ActivityFeedItem, UserCredibility, CredibilityTier } from '../types'
+import type { ActivityFeedItem, UserCredibility, CredibilityTier, ActivityComment } from '../types'
 import {
   MapPin, Star, Tag, Calendar, Award, TrendingUp,
   ThumbsUp, MessageCircle, Clock, Shield, CheckCircle2,
-  Users, Flame, ChevronUp
+  Users, Flame, ChevronUp, Send
 } from 'lucide-react'
 
 const activityIcons: Record<string, typeof MapPin> = {
@@ -59,7 +59,7 @@ function CredibilityBadge({ tier }: { tier: CredibilityTier }) {
 }
 
 export default function ActivityFeedPage() {
-  const { isAuthenticated } = useAuth()
+  const { isAuthenticated, user } = useAuth()
   const [feedItems, setFeedItems] = useState<ActivityFeedItem[]>([])
   const [myCredibility, setMyCredibility] = useState<UserCredibility | null>(null)
   const [loading, setLoading] = useState(true)
@@ -67,6 +67,13 @@ export default function ActivityFeedPage() {
   const [loadingMore, setLoadingMore] = useState(false)
   const [page, setPage] = useState(1)
   const [hasMore, setHasMore] = useState(true)
+  const [likedItems, setLikedItems] = useState<Set<string>>(new Set())
+  const [commentsByItem, setCommentsByItem] = useState<Record<string, ActivityComment[]>>({})
+  const [expandedComments, setExpandedComments] = useState<Set<string>>(new Set())
+  const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({})
+  const [pendingLikes, setPendingLikes] = useState<Set<string>>(new Set())
+  const [pendingComments, setPendingComments] = useState<Set<string>>(new Set())
+  const [actionError, setActionError] = useState<string | null>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
 
   const loadFeed = useCallback(async (pageNum: number, append: boolean = false) => {
@@ -79,6 +86,17 @@ export default function ActivityFeedPage() {
 
       setHasMore(result.has_more)
       setFeedItems(prev => append ? [...prev, ...items] : items)
+      if (user?.id) {
+        const liked = items
+          .filter(item => item.liked_by?.includes(user.id))
+          .map(item => item.id)
+        setLikedItems(prev => {
+          const next = new Set(prev)
+          if (!append) next.clear()
+          liked.forEach(id => next.add(id))
+          return next
+        })
+      }
       setPage(pageNum)
     } catch (err) {
       console.error('Failed to load feed:', err)
@@ -90,11 +108,107 @@ export default function ActivityFeedPage() {
       setLoading(false)
       setLoadingMore(false)
     }
-  }, [])
+  }, [user?.id])
 
   useEffect(() => {
     loadFeed(1)
   }, [loadFeed])
+
+  const loadComments = useCallback(async (activityId: string) => {
+    try {
+      const comments = await api.getActivityComments(activityId)
+      setCommentsByItem(prev => ({ ...prev, [activityId]: comments }))
+    } catch (err) {
+      console.error('Failed to load comments:', err)
+      setActionError('Could not load comments right now.')
+    }
+  }, [])
+
+  const toggleLike = useCallback(async (activityId: string) => {
+    if (!isAuthenticated) {
+      setActionError('Please sign in to like posts.')
+      return
+    }
+    if (pendingLikes.has(activityId)) return
+
+    setPendingLikes(prev => new Set(prev).add(activityId))
+    setActionError(null)
+    try {
+      const result = await api.toggleActivityLike(activityId)
+      setLikedItems(prev => {
+        const next = new Set(prev)
+        if (result.liked) next.add(activityId)
+        else next.delete(activityId)
+        return next
+      })
+      setFeedItems(prev => prev.map(item => (
+        item.id === activityId
+          ? { ...item, likes: result.likes, comments: result.comments }
+          : item
+      )))
+    } catch (err) {
+      console.error('Failed to toggle like:', err)
+      setActionError(err instanceof Error ? err.message : 'Could not update like.')
+    } finally {
+      setPendingLikes(prev => {
+        const next = new Set(prev)
+        next.delete(activityId)
+        return next
+      })
+    }
+  }, [isAuthenticated, pendingLikes])
+
+  const toggleComments = useCallback(async (activityId: string) => {
+    const isOpen = expandedComments.has(activityId)
+    if (isOpen) {
+      setExpandedComments(prev => {
+        const next = new Set(prev)
+        next.delete(activityId)
+        return next
+      })
+      return
+    }
+
+    setExpandedComments(prev => new Set(prev).add(activityId))
+    if (!commentsByItem[activityId]) {
+      await loadComments(activityId)
+    }
+  }, [commentsByItem, expandedComments, loadComments])
+
+  const submitComment = useCallback(async (activityId: string) => {
+    const content = (commentDrafts[activityId] || '').trim()
+    if (!content) return
+    if (!isAuthenticated) {
+      setActionError('Please sign in to comment.')
+      return
+    }
+    if (pendingComments.has(activityId)) return
+
+    setPendingComments(prev => new Set(prev).add(activityId))
+    setActionError(null)
+    try {
+      const result = await api.addActivityComment(activityId, content)
+      setCommentsByItem(prev => {
+        const current = prev[activityId] || []
+        return { ...prev, [activityId]: [...current, result.comment] }
+      })
+      setCommentDrafts(prev => ({ ...prev, [activityId]: '' }))
+      setFeedItems(prev => prev.map(item => (
+        item.id === activityId
+          ? { ...item, comments: result.comments }
+          : item
+      )))
+    } catch (err) {
+      console.error('Failed to add comment:', err)
+      setActionError(err instanceof Error ? err.message : 'Could not post comment.')
+    } finally {
+      setPendingComments(prev => {
+        const next = new Set(prev)
+        next.delete(activityId)
+        return next
+      })
+    }
+  }, [commentDrafts, isAuthenticated, pendingComments])
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -141,6 +255,11 @@ export default function ActivityFeedPage() {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
           {/* Main Feed */}
           <div className="lg:col-span-2 space-y-4">
+            {actionError && (
+              <div className="glass-card rounded-2xl p-3 border border-red-300/40 bg-red-500/5">
+                <p className="text-caption text-red-600 dark:text-red-400">{actionError}</p>
+              </div>
+            )}
             {loading ? (
               Array.from({ length: 5 }).map((_, i) => (
                 <div key={i} className="glass-card rounded-2xl p-5 animate-pulse">
@@ -183,6 +302,11 @@ export default function ActivityFeedPage() {
               feedItems.map((item, index) => {
                 const Icon = activityIcons[item.activity_type] || TrendingUp
                 const color = activityColors[item.activity_type] || 'bg-surface-elevated'
+                const isLiked = likedItems.has(item.id)
+                const isCommentsOpen = expandedComments.has(item.id)
+                const itemComments = commentsByItem[item.id] || item.comments_list || []
+                const isLikePending = pendingLikes.has(item.id)
+                const isCommentPending = pendingComments.has(item.id)
 
                 return (
                   <div
@@ -236,15 +360,65 @@ export default function ActivityFeedPage() {
 
                         {/* Engagement */}
                         <div className="flex items-center gap-4 mt-3">
-                          <button className="flex items-center gap-1.5 text-caption text-[hsl(var(--muted-foreground))] hover:text-brand transition-colors">
+                          <button
+                            onClick={() => toggleLike(item.id)}
+                            disabled={isLikePending}
+                            className={`flex items-center gap-1.5 text-caption transition-colors ${isLiked ? 'text-brand' : 'text-[hsl(var(--muted-foreground))] hover:text-brand'} ${isLikePending ? 'opacity-50 cursor-not-allowed' : ''}`}
+                          >
                             <ThumbsUp className="w-3.5 h-3.5" />
-                            {item.likes > 0 && item.likes}
+                            <span>{item.likes > 0 ? item.likes : (isLiked ? 1 : 'Like')}</span>
                           </button>
-                          <button className="flex items-center gap-1.5 text-caption text-[hsl(var(--muted-foreground))] hover:text-brand transition-colors">
+                          <button
+                            onClick={() => toggleComments(item.id)}
+                            className={`flex items-center gap-1.5 text-caption transition-colors ${isCommentsOpen ? 'text-brand' : 'text-[hsl(var(--muted-foreground))] hover:text-brand'}`}
+                          >
                             <MessageCircle className="w-3.5 h-3.5" />
-                            {item.comments > 0 && item.comments}
+                            <span>{item.comments > 0 ? item.comments : 'Comment'}</span>
                           </button>
                         </div>
+
+                        {isCommentsOpen && (
+                          <div className="mt-3 pt-3 border-t border-[hsl(var(--border))] space-y-2.5">
+                            {itemComments.length === 0 ? (
+                              <p className="text-caption text-[hsl(var(--muted-foreground))]">No comments yet.</p>
+                            ) : (
+                              <div className="space-y-2 max-h-52 overflow-y-auto pr-1">
+                                {itemComments.map((comment) => (
+                                  <div key={comment.id} className="rounded-lg bg-[hsl(var(--secondary))]/50 px-2.5 py-2">
+                                    <p className="text-caption font-medium text-[hsl(var(--foreground))]">{comment.user_name}</p>
+                                    <p className="text-ui text-[hsl(var(--muted-foreground))] break-words">{comment.content}</p>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+
+                            <div className="flex items-center gap-2">
+                              <input
+                                type="text"
+                                value={commentDrafts[item.id] || ''}
+                                onChange={(e) => setCommentDrafts(prev => ({ ...prev, [item.id]: e.target.value }))}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter') {
+                                    e.preventDefault()
+                                    submitComment(item.id)
+                                  }
+                                }}
+                                placeholder={isAuthenticated ? 'Write a comment…' : 'Sign in to comment'}
+                                disabled={!isAuthenticated || isCommentPending}
+                                maxLength={500}
+                                className="flex-1 h-9 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--background))] px-3 text-sm text-[hsl(var(--foreground))] placeholder:text-[hsl(var(--muted-foreground))] disabled:opacity-60"
+                              />
+                              <button
+                                onClick={() => submitComment(item.id)}
+                                disabled={!isAuthenticated || isCommentPending || !(commentDrafts[item.id] || '').trim()}
+                                className="h-9 w-9 rounded-lg bg-brand text-brand-on-primary flex items-center justify-center disabled:opacity-50"
+                                aria-label="Post comment"
+                              >
+                                <Send className="w-4 h-4" />
+                              </button>
+                            </div>
+                          </div>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -226,7 +226,23 @@ export interface ActivityFeedItem {
   description?: string;
   likes: number;
   comments: number;
+  liked_by?: string[];
+  comments_list?: ActivityComment[];
   created_at: string;
+}
+
+export interface ActivityComment {
+  id: string;
+  user_id: string;
+  user_name: string;
+  content: string;
+  created_at: string;
+}
+
+export interface ActivityLikeResult {
+  liked: boolean;
+  likes: number;
+  comments: number;
 }
 
 export interface BusinessActivityStatus {


### PR DESCRIPTION
Add backend endpoints and frontend integration for liking and commenting on activity feed items. Backend: permit localhost CORS via regex; add POST /feed/{activity_id}/like to toggle likes and maintain like counts; add GET/POST /feed/{activity_id}/comments to list and create comments; introduce Pydantic models for ActivityComment and ActivityCommentCreate and ensure counts are normalized. Frontend: extend types with ActivityComment and ActivityLikeResult; add api methods toggleActivityLike, getActivityComments and addActivityComment; update ActivityFeedPage to manage like/comment UI, state (liked items, comments cache, pending actions, drafts), and handlers for toggling likes and posting comments with error handling and optimistic updates. Minor package metadata updates included.