### PR TITLE
Add user profile endpoints and UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from routes.claims import router as claims_router
 from routes.subscriptions import router as subscriptions_router
 from routes.activity import router as activity_router
 from routes.discovery import router as discovery_router
+from routes.users import router as users_router
 
 
 @asynccontextmanager
@@ -63,6 +64,7 @@ app.include_router(claims_router, prefix="/api", tags=["Claims"])
 app.include_router(subscriptions_router, prefix="/api", tags=["Subscriptions"])
 app.include_router(activity_router, prefix="/api", tags=["Activity"])
 app.include_router(discovery_router, prefix="/api", tags=["Discovery"])
+app.include_router(users_router, prefix="/api/users", tags=["Users"])
 
 
 @app.get("/")

--- a/backend/migrate_comment_pictures.py
+++ b/backend/migrate_comment_pictures.py
@@ -1,0 +1,87 @@
+"""
+Migration script to backfill profile_picture field for existing comments
+Run this once to update all existing comments with user profile pictures
+"""
+
+import asyncio
+from pymongo import MongoClient
+from bson import ObjectId
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MONGODB_URL = os.getenv("MONGODB_URL", "mongodb://localhost:27017")
+DATABASE_NAME = os.getenv("DATABASE_NAME", "vantage")
+
+
+def migrate_comment_pictures():
+    """Add profile_picture to all existing comments in activity feed"""
+    client = MongoClient(MONGODB_URL)
+    db = client[DATABASE_NAME]
+    
+    activity_feed = db.activity_feed
+    users = db.users
+    
+    print("Starting migration: Adding profile_picture to comments...")
+    
+    # Get all activity items with comments
+    cursor = activity_feed.find({"comments_list": {"$exists": True, "$ne": []}})
+    
+    updated_count = 0
+    total_items = 0
+    total_comments = 0
+    
+    for item in cursor:
+        total_items += 1
+        comments_list = item.get("comments_list", [])
+        
+        if not comments_list:
+            continue
+        
+        updated_comments = []
+        item_updated = False
+        
+        for comment in comments_list:
+            total_comments += 1
+            
+            # Skip if already has profile_picture
+            if "profile_picture" in comment:
+                updated_comments.append(comment)
+                continue
+            
+            # Fetch user's profile picture
+            user_id = comment.get("user_id")
+            if user_id:
+                try:
+                    user = users.find_one({"_id": ObjectId(user_id)})
+                    if user:
+                        comment["profile_picture"] = user.get("profile_picture")
+                        item_updated = True
+                        print(f"  Added profile_picture for user: {user.get('name')} (comment in activity {item['_id']})")
+                except Exception as e:
+                    print(f"  Warning: Could not find user {user_id}: {e}")
+                    comment["profile_picture"] = None
+            else:
+                comment["profile_picture"] = None
+            
+            updated_comments.append(comment)
+        
+        # Update the activity item with modified comments
+        if item_updated:
+            activity_feed.update_one(
+                {"_id": item["_id"]},
+                {"$set": {"comments_list": updated_comments}}
+            )
+            updated_count += 1
+    
+    print(f"\nMigration complete!")
+    print(f"  Total activity items checked: {total_items}")
+    print(f"  Total comments processed: {total_comments}")
+    print(f"  Activity items updated: {updated_count}")
+    
+    client.close()
+
+
+if __name__ == "__main__":
+    migrate_comment_pictures()

--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -96,6 +96,11 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
         raise credentials_exception
     
     user["id"] = str(user["_id"])
+    
+    # Convert datetime to string for created_at field
+    if "created_at" in user and user["created_at"]:
+        user["created_at"] = user["created_at"].isoformat()
+    
     return User(**user)
 
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -35,6 +35,9 @@ class User(UserBase):
     favorites: List[str] = Field(default_factory=list)
     google_id: Optional[str] = None
     auth_provider: Optional[str] = None
+    profile_picture: Optional[str] = None
+    about_me: Optional[str] = None
+    created_at: Optional[str] = None
     
     class Config:
         from_attributes = True
@@ -43,6 +46,13 @@ class User(UserBase):
 class UserInDB(User):
     """User schema as stored in database (includes password hash)"""
     hashed_password: Optional[str] = None  # Optional for OAuth users
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating user profile"""
+    name: Optional[str] = Field(None, min_length=2, max_length=100)
+    profile_picture: Optional[str] = Field(None, max_length=500)
+    about_me: Optional[str] = Field(None, max_length=500)
 
 
 class UserLogin(BaseModel):

--- a/backend/routes/activity.py
+++ b/backend/routes/activity.py
@@ -47,6 +47,7 @@ class ActivityComment(BaseModel):
     id: str
     user_id: str
     user_name: str
+    profile_picture: Optional[str] = None
     content: str
     created_at: datetime
 
@@ -62,6 +63,12 @@ def activity_helper(doc) -> dict:
     if doc:
         doc["id"] = str(doc["_id"])
         del doc["_id"]
+        # Don't include comments_list in feed - fetch separately via /comments endpoint
+        if "comments_list" in doc:
+            del doc["comments_list"]
+        # Don't include liked_by array in feed - it can be large
+        if "liked_by" in doc:
+            del doc["liked_by"]
     return doc
 
 
@@ -351,6 +358,7 @@ async def get_activity_comments(activity_id: str):
             id=str(comment.get("id") or ""),
             user_id=comment.get("user_id", ""),
             user_name=comment.get("user_name", "Anonymous"),
+            profile_picture=comment.get("profile_picture"),
             content=comment.get("content", ""),
             created_at=comment.get("created_at", datetime.utcnow()),
         )
@@ -375,6 +383,7 @@ async def add_activity_comment(
         "id": str(ObjectId()),
         "user_id": current_user.id,
         "user_name": current_user.name,
+        "profile_picture": current_user.profile_picture,
         "content": payload.content.strip(),
         "created_at": datetime.utcnow(),
     }

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -1,0 +1,116 @@
+"""
+User Routes for Vantage
+Handles viewing and updating user profiles
+"""
+
+from datetime import datetime
+from fastapi import APIRouter, HTTPException, status, Depends
+from models.user import User, UserUpdate
+from models.auth import get_current_user
+from database.mongodb import get_users_collection
+
+router = APIRouter()
+
+
+@router.get("/{user_id}", response_model=User)
+async def get_user_profile(user_id: str):
+    """
+    Get a user's public profile information by user ID
+    - No authentication required
+    - Returns public user data
+    """
+    try:
+        users_collection = get_users_collection()
+    except Exception as db_error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Database unavailable: {str(db_error)}"
+        )
+    
+    from bson import ObjectId
+    from bson.errors import InvalidId
+    
+    try:
+        user = await users_collection.find_one({"_id": ObjectId(user_id)})
+    except InvalidId:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid user ID format"
+        )
+    
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found"
+        )
+    
+    user["id"] = str(user["_id"])
+    
+    # Convert datetime to string for created_at field
+    if "created_at" in user and user["created_at"]:
+        user["created_at"] = user["created_at"].isoformat()
+    
+    return User(**user)
+
+
+@router.put("/me", response_model=User)
+async def update_user_profile(
+    user_update: UserUpdate,
+    current_user: User = Depends(get_current_user)
+):
+    """
+    Update the current user's profile
+    - Requires authentication
+    - Updates name, profile_picture, and/or about_me
+    """
+    try:
+        users_collection = get_users_collection()
+    except Exception as db_error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Database unavailable: {str(db_error)}"
+        )
+    
+    # Build update dict with only provided fields
+    update_data = {}
+    if user_update.name is not None:
+        update_data["name"] = user_update.name
+    if user_update.profile_picture is not None:
+        update_data["profile_picture"] = user_update.profile_picture
+    if user_update.about_me is not None:
+        update_data["about_me"] = user_update.about_me
+    
+    if not update_data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No fields to update"
+        )
+    
+    update_data["updated_at"] = datetime.utcnow()
+    
+    from bson import ObjectId
+    
+    # Update user in database
+    result = await users_collection.update_one(
+        {"_id": ObjectId(current_user.id)},
+        {"$set": update_data}
+    )
+    
+    if result.modified_count == 0:
+        # User might not exist or no changes were made
+        user = await users_collection.find_one({"_id": ObjectId(current_user.id)})
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found"
+            )
+    
+    # Fetch updated user
+    updated_user = await users_collection.find_one({"_id": ObjectId(current_user.id)})
+    updated_user["id"] = str(updated_user["_id"])
+    
+    # Convert datetime to string for created_at field
+    if "created_at" in updated_user and updated_user["created_at"]:
+        updated_user["created_at"] = updated_user["created_at"].isoformat()
+    
+    return User(**updated_user)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { Business, Review, Deal, ReviewCreate, User, AuthTokens, BusinessClaim, ClaimCreate, Subscription, SubscriptionCreate, TierInfo, CheckIn, CheckInCreate, UserCredibility, ActivityFeedItem, BusinessActivityStatus, ActivityComment, ActivityLikeResult } from './types';
+import type { Business, Review, Deal, ReviewCreate, User, AuthTokens, BusinessClaim, ClaimCreate, Subscription, SubscriptionCreate, TierInfo, CheckIn, CheckInCreate, UserCredibility, ActivityFeedItem, BusinessActivityStatus, ActivityComment, ActivityLikeResult, UserUpdate } from './types';
 
 const API_URL = import.meta.env.VITE_API_URL ? `${import.meta.env.VITE_API_URL}/api` : 'http://localhost:8000/api';
 
@@ -56,6 +56,29 @@ export const api = {
     if (!response.ok) {
       const data = await response.json().catch(() => ({}));
       throw new Error(data.detail || 'Google authentication failed');
+    }
+    return response.json();
+  },
+
+  // ─── Users ───────────────────────────────────
+  async getUserProfile(userId: string): Promise<User> {
+    const response = await fetch(`${API_URL}/users/${userId}`);
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.detail || 'Failed to fetch user profile');
+    }
+    return response.json();
+  },
+
+  async updateMyProfile(updates: UserUpdate): Promise<User> {
+    const response = await fetch(`${API_URL}/users/me`, {
+      method: 'PUT',
+      headers: getAuthHeaders(),
+      body: JSON.stringify(updates),
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error(data.detail || 'Failed to update profile');
     }
     return response.json();
   },

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ interface AuthContextType {
   signUp: (name: string, email: string, password: string, role: string) => Promise<{ error: string | null }>;
   signInWithGoogle: (credential: string) => Promise<{ error: string | null }>;
   signOut: () => void;
+  setUser: (user: User | null) => void;
   isAuthenticated: boolean;
 }
 
@@ -20,6 +21,7 @@ const AuthContext = createContext<AuthContextType>({
   signUp: async () => ({ error: null }),
   signInWithGoogle: async () => ({ error: null }),
   signOut: () => {},
+  setUser: () => {},
   isAuthenticated: false,
 });
 
@@ -105,6 +107,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         signUp,
         signInWithGoogle,
         signOut,
+        setUser,
         isAuthenticated: !!user,
       }}
     >

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -9,6 +9,7 @@ import Businesses from './pages/Businesses'
 import LoginPage from './pages/LoginPage'
 import SignUpPage from './pages/SignUpPage'
 import AccountPage from './pages/AccountPage'
+import UserProfilePage from './pages/UserProfilePage'
 import PricingPage from './pages/PricingPage'
 import ActivityFeedPage from './pages/ActivityFeedPage'
 import DashboardPage from './pages/DashboardPage'
@@ -33,6 +34,7 @@ createRoot(document.getElementById('root')!).render(
               <Route path="/login" element={<LoginPage />} />
               <Route path="/signup" element={<SignUpPage />} />
               <Route path="/account" element={<AccountPage />} />
+              <Route path="/user/:userId" element={<UserProfilePage />} />
             </Routes>
           </RootLayout>
         </AuthProvider>

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -1,14 +1,18 @@
 import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import { useNavigate, Link } from 'react-router-dom'
-import { User, Mail, Shield, Calendar, LogOut, Edit3, Save, X, ArrowLeft, Store, Heart } from 'lucide-react'
+import { User, Mail, Shield, Calendar, LogOut, Edit3, Save, X, ArrowLeft, Store, Heart, ImageIcon, FileText } from 'lucide-react'
+import { api } from '../api'
 
 export default function AccountPage() {
-  const { user, isAuthenticated, signOut } = useAuth()
+  const { user, isAuthenticated, signOut, setUser } = useAuth()
   const navigate = useNavigate()
   const [isEditing, setIsEditing] = useState(false)
   const [name, setName] = useState(() => user?.name || '')
-  const [email, setEmail] = useState(() => user?.email || '')
+  const [profilePicture, setProfilePicture] = useState(() => user?.profile_picture || '')
+  const [aboutMe, setAboutMe] = useState(() => user?.about_me || '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState('')
 
   if (!isAuthenticated || !user) {
     return (
@@ -33,6 +37,31 @@ export default function AccountPage() {
   const handleSignOut = async () => {
     await signOut()
     navigate('/')
+  }
+
+  const handleSaveProfile = async () => {
+    setError('')
+    setIsSaving(true)
+    
+    try {
+      const updates: any = {}
+      if (name !== user?.name) updates.name = name
+      if (profilePicture !== user?.profile_picture) updates.profile_picture = profilePicture
+      if (aboutMe !== user?.about_me) updates.about_me = aboutMe
+      
+      if (Object.keys(updates).length === 0) {
+        setIsEditing(false)
+        return
+      }
+      
+      const updatedUser = await api.updateMyProfile(updates)
+      setUser(updatedUser) // Update context with new user data
+      setIsEditing(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update profile')
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   const roleLabels: Record<string, string> = {
@@ -61,13 +90,26 @@ export default function AccountPage() {
           <div className="glass-card rounded-2xl p-8 mb-6">
             <div className="flex items-start gap-5">
               {/* Avatar */}
-              <div className="w-20 h-20 rounded-2xl gradient-primary flex items-center justify-center text-heading font-bold text-on-primary shadow-lg shadow-brand/20 flex-shrink-0">
-                {(user.name || user.email)[0].toUpperCase()}
+              <div className="w-20 h-20 rounded-2xl flex-shrink-0 overflow-hidden shadow-lg shadow-brand/20">
+                {user.profile_picture ? (
+                  <img 
+                    src={user.profile_picture} 
+                    alt={user.name}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full gradient-primary flex items-center justify-center text-heading font-bold text-on-primary">
+                    {(user.name || user.email)[0].toUpperCase()}
+                  </div>
+                )}
               </div>
 
               <div className="flex-1 min-w-0">
                 <h1 className="text-subheading font-bold text-[hsl(var(--foreground))] font-heading">{user.name}</h1>
                 <p className="text-[hsl(var(--muted-foreground))]">{user.email}</p>
+                {user.about_me && (
+                  <p className="text-ui text-[hsl(var(--foreground))] mt-2">{user.about_me}</p>
+                )}
                 <div className="flex items-center gap-2 mt-2">
                   <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-caption font-medium bg-[hsl(var(--primary))]/10 text-[hsl(var(--primary))]">
                     <RoleIcon className="w-3 h-3" />
@@ -95,6 +137,11 @@ export default function AccountPage() {
           {isEditing && (
             <div className="glass-card rounded-2xl p-6 mb-6 animate-fade-in">
               <h3 className="font-semibold text-[hsl(var(--foreground))] mb-4">Edit Profile</h3>
+              {error && (
+                <div className="mb-4 p-3 rounded-lg bg-error/10 border border-error/20 text-error text-ui">
+                  {error}
+                </div>
+              )}
               <div className="space-y-4">
                 <div>
                   <label className="text-ui font-medium text-[hsl(var(--foreground))] mb-1.5 block">Name</label>
@@ -114,19 +161,63 @@ export default function AccountPage() {
                     <Mail className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[hsl(var(--muted-foreground))]" />
                     <input
                       type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
+                      value={user?.email || ''}
+                      disabled
+                      className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--muted))] text-ui opacity-60 cursor-not-allowed"
+                    />
+                  </div>
+                  <p className="text-caption text-[hsl(var(--muted-foreground))] mt-1.5">Email cannot be changed</p>
+                </div>
+                <div>
+                  <label className="text-ui font-medium text-[hsl(var(--foreground))] mb-1.5 block">Profile Picture URL</label>
+                  <div className="relative">
+                    <ImageIcon className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[hsl(var(--muted-foreground))]" />
+                    <input
+                      type="url"
+                      value={profilePicture}
+                      onChange={(e) => setProfilePicture(e.target.value)}
+                      placeholder="https://example.com/photo.jpg"
                       className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--background))] text-ui focus:outline-none focus:ring-2 focus:ring-[hsl(var(--primary))]/20 focus:border-[hsl(var(--primary))]"
                     />
                   </div>
+                  <p className="text-caption text-[hsl(var(--muted-foreground))] mt-1.5">Enter a URL to your profile picture</p>
+                </div>
+                <div>
+                  <label className="text-ui font-medium text-[hsl(var(--foreground))] mb-1.5 block">About Me</label>
+                  <div className="relative">
+                    <FileText className="absolute left-3.5 top-3 w-4 h-4 text-[hsl(var(--muted-foreground))]" />
+                    <textarea
+                      value={aboutMe}
+                      onChange={(e) => setAboutMe(e.target.value)}
+                      placeholder="Tell others about yourself..."
+                      maxLength={500}
+                      rows={4}
+                      className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--background))] text-ui focus:outline-none focus:ring-2 focus:ring-[hsl(var(--primary))]/20 focus:border-[hsl(var(--primary))] resize-none"
+                    />
+                  </div>
+                  <p className="text-caption text-[hsl(var(--muted-foreground))] mt-1.5">{aboutMe.length}/500 characters</p>
                 </div>
                 <div className="flex gap-2 justify-end pt-2">
-                  <button onClick={() => setIsEditing(false)} className="px-4 py-2.5 rounded-xl text-ui font-medium text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--secondary))] transition-colors">
+                  <button 
+                    onClick={() => {
+                      setIsEditing(false)
+                      setError('')
+                      setName(user?.name || '')
+                      setProfilePicture(user?.profile_picture || '')
+                      setAboutMe(user?.about_me || '')
+                    }} 
+                    className="px-4 py-2.5 rounded-xl text-ui font-medium text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--secondary))] transition-colors"
+                    disabled={isSaving}
+                  >
                     Cancel
                   </button>
-                  <button className="px-5 py-2.5 rounded-xl text-ui font-medium gradient-primary text-on-primary flex items-center gap-2 shadow-lg shadow-brand/20">
+                  <button 
+                    onClick={handleSaveProfile}
+                    disabled={isSaving}
+                    className="px-5 py-2.5 rounded-xl text-ui font-medium gradient-primary text-on-primary flex items-center gap-2 shadow-lg shadow-brand/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
                     <Save className="w-4 h-4" />
-                    Save Changes
+                    {isSaving ? 'Saving...' : 'Save Changes'}
                   </button>
                 </div>
               </div>

--- a/frontend/src/pages/ActivityFeedPage.tsx
+++ b/frontend/src/pages/ActivityFeedPage.tsx
@@ -170,10 +170,9 @@ export default function ActivityFeedPage() {
     }
 
     setExpandedComments(prev => new Set(prev).add(activityId))
-    if (!commentsByItem[activityId]) {
-      await loadComments(activityId)
-    }
-  }, [commentsByItem, expandedComments, loadComments])
+    // Always refresh comments to ensure we have latest data with profile pictures
+    await loadComments(activityId)
+  }, [expandedComments, loadComments])
 
   const submitComment = useCallback(async (activityId: string) => {
     const content = (commentDrafts[activityId] || '').trim()
@@ -385,8 +384,26 @@ export default function ActivityFeedPage() {
                               <div className="space-y-2 max-h-52 overflow-y-auto pr-1">
                                 {itemComments.map((comment) => (
                                   <div key={comment.id} className="rounded-lg bg-[hsl(var(--secondary))]/50 px-2.5 py-2">
-                                    <p className="text-caption font-medium text-[hsl(var(--foreground))]">{comment.user_name}</p>
-                                    <p className="text-ui text-[hsl(var(--muted-foreground))] break-words">{comment.content}</p>
+                                    <div className="flex items-start gap-2">
+                                      {/* User Avatar */}
+                                      <div className="w-6 h-6 rounded-full flex-shrink-0 overflow-hidden">
+                                        {comment.profile_picture ? (
+                                          <img 
+                                            src={comment.profile_picture} 
+                                            alt={comment.user_name || 'User'}
+                                            className="w-full h-full object-cover"
+                                          />
+                                        ) : (
+                                          <div className="w-full h-full gradient-primary flex items-center justify-center text-[10px] font-bold text-on-primary">
+                                            {(comment.user_name || 'A')[0].toUpperCase()}
+                                          </div>
+                                        )}
+                                      </div>
+                                      <div className="flex-1 min-w-0">
+                                        <p className="text-caption font-medium text-[hsl(var(--foreground))]">{comment.user_name || 'Anonymous'}</p>
+                                        <p className="text-ui text-[hsl(var(--muted-foreground))] break-words">{comment.content}</p>
+                                      </div>
+                                    </div>
                                   </div>
                                 ))}
                               </div>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,0 +1,155 @@
+import { useState, useEffect } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { User, Shield, Calendar, ArrowLeft, Store } from 'lucide-react'
+import { api } from '../api'
+import type { User as UserType } from '../types'
+
+export default function UserProfilePage() {
+  const { userId } = useParams<{ userId: string }>()
+  const [user, setUser] = useState<UserType | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      if (!userId) {
+        setError('User ID is required')
+        setLoading(false)
+        return
+      }
+
+      try {
+        const userData = await api.getUserProfile(userId)
+        setUser(userData)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load user profile')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchUserProfile()
+  }, [userId])
+
+  if (loading) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center p-6">
+        <div className="text-center">
+          <div className="w-12 h-12 border-4 border-[hsl(var(--primary))] border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+          <p className="text-[hsl(var(--muted-foreground))]">Loading profile...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !user) {
+    return (
+      <div className="min-h-[60vh] flex items-center justify-center p-6">
+        <div className="glass-card rounded-2xl p-10 max-w-md w-full text-center animate-fade-in-up">
+          <div className="w-16 h-16 rounded-2xl bg-error/10 flex items-center justify-center mx-auto mb-6">
+            <User className="w-8 h-8 text-error" />
+          </div>
+          <h2 className="text-subheading font-bold text-[hsl(var(--foreground))] mb-2 font-heading">Profile not found</h2>
+          <p className="text-[hsl(var(--muted-foreground))] mb-6">{error || 'This user profile could not be found'}</p>
+          <Link
+            to="/businesses"
+            className="inline-flex items-center justify-center px-6 py-3 rounded-xl gradient-primary text-on-primary font-medium shadow-lg shadow-brand/20"
+          >
+            Back to Explore
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const roleLabels: Record<string, string> = {
+    customer: 'Customer',
+    business_owner: 'Business Owner',
+    admin: 'Administrator',
+  }
+  const roleIcons: Record<string, typeof User> = {
+    customer: User,
+    business_owner: Store,
+    admin: Shield,
+  }
+  const RoleIcon = roleIcons[user.role] || User
+
+  return (
+    <div className="min-h-[60vh] py-10 px-4">
+      <div className="max-w-2xl mx-auto">
+        {/* Back */}
+        <Link to="/businesses" className="inline-flex items-center gap-1 text-ui text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))] mb-6 transition-colors">
+          <ArrowLeft className="w-4 h-4" />
+          Back to Explore
+        </Link>
+
+        <div className="animate-fade-in-up">
+          {/* Profile Header */}
+          <div className="glass-card rounded-2xl p-8 mb-6">
+            <div className="flex items-start gap-5">
+              {/* Avatar */}
+              <div className="w-24 h-24 rounded-2xl flex-shrink-0 overflow-hidden shadow-lg shadow-brand/20">
+                {user.profile_picture ? (
+                  <img 
+                    src={user.profile_picture} 
+                    alt={user.name}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full gradient-primary flex items-center justify-center text-heading-xl font-bold text-on-primary">
+                    {(user.name || user.email)[0].toUpperCase()}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <h1 className="text-heading font-bold text-[hsl(var(--foreground))] font-heading">{user.name}</h1>
+                <div className="flex items-center gap-2 mt-2">
+                  <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-caption font-medium bg-[hsl(var(--primary))]/10 text-[hsl(var(--primary))]">
+                    <RoleIcon className="w-3 h-3" />
+                    {roleLabels[user.role] || user.role}
+                  </span>
+                  {user.created_at && (
+                    <span className="inline-flex items-center gap-1 text-caption text-[hsl(var(--muted-foreground))]">
+                      <Calendar className="w-3 h-3" />
+                      Joined {new Date(user.created_at).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* About Section */}
+          {user.about_me && (
+            <div className="glass-card rounded-2xl p-6 mb-6">
+              <h3 className="font-semibold text-[hsl(var(--foreground))] mb-3">About</h3>
+              <p className="text-ui text-[hsl(var(--foreground))] leading-relaxed whitespace-pre-wrap">
+                {user.about_me}
+              </p>
+            </div>
+          )}
+
+          {/* Additional Info */}
+          <div className="glass-card rounded-2xl p-6">
+            <h3 className="font-semibold text-[hsl(var(--foreground))] mb-4">Member Information</h3>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between py-2 border-b border-[hsl(var(--border))]">
+                <span className="text-ui text-[hsl(var(--muted-foreground))]">Account Type</span>
+                <span className="text-ui font-medium text-[hsl(var(--foreground))]">{roleLabels[user.role] || user.role}</span>
+              </div>
+              {user.created_at && (
+                <div className="flex items-center justify-between py-2">
+                  <span className="text-ui text-[hsl(var(--muted-foreground))]">Member Since</span>
+                  <span className="text-ui font-medium text-[hsl(var(--foreground))]">
+                    {new Date(user.created_at).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -107,6 +107,14 @@ export interface User {
   email: string;
   role: 'customer' | 'business_owner' | 'admin';
   created_at?: string;
+  profile_picture?: string;
+  about_me?: string;
+}
+
+export interface UserUpdate {
+  name?: string;
+  profile_picture?: string;
+  about_me?: string;
 }
 
 export interface AuthTokens {
@@ -241,6 +249,7 @@ export interface ActivityComment {
   id: string;
   user_id: string;
   user_name: string;
+  profile_picture?: string;
   content: string;
   created_at: string;
 }


### PR DESCRIPTION
Backend: introduce /api/users router with GET /{user_id} and PUT /me to view and update public profiles; add UserUpdate schema and profile_picture/about_me/created_at fields to User model; include users router in main.py; update auth helper to stringify created_at. Add migrate_comment_pictures.py to backfill profile_picture on existing comments. Update activity routes to include comment.profile_picture, exclude comments_list/liked_by from feed items, and attach profile_picture when creating comments.

Frontend: add UserUpdate type and API methods getUserProfile/updateMyProfile; expose setUser in AuthContext; register /user/:userId route and add UserProfilePage component; enhance AccountPage to edit/save name, profile picture URL and about_me, call API and update context; show avatars in activity comments and always refresh comments when expanding. Update types to include profile_picture and about_me.