### PR TITLE
build(deps): bump PyJWT from 2.11.0 to 2.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pydantic-settings==2.13.0
 pydantic_core==2.41.5
 pymongo==4.9.2
 python-dotenv==1.0.1
-PyJWT==2.11.0
+PyJWT==2.12.1
 python-multipart==0.0.22
 rsa==4.9.1
 six==1.17.0


### PR DESCRIPTION
Fixes high-severity vulnerability (GHSA-75c5-xw7c-p5pm) where PyJWT failed to reject tokens containing unknown extensions in the `crit` (critical) JWT header parameter. Per RFC 7515, tokens with unrecognized critical extensions must be rejected — without this, an attacker could craft tokens that bypass validation.