### PR TITLE
style(ui): Force Google button font and small header buttons

### DIFF
--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -156,13 +156,13 @@ export function Header() {
           ) : (
             <div className="hidden items-center gap-2 md:flex">
               <Link to="/login">
-                <Button variant="ghost" size="sm" className="gap-1.5 min-w-[100px]">
+                <Button variant="ghost" size="sm" className="gap-1.5 min-w-[100px] text-sm">
                   <LogIn className="h-4 w-4" />
                   Sign In
                 </Button>
               </Link>
               <Link to="/signup">
-                <Button size="sm" className="gap-1.5 min-w-[100px]">
+                <Button size="sm" className="gap-1.5 min-w-[100px] text-sm">
                   <UserPlus className="h-4 w-4" />
                   Sign Up
                 </Button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -113,6 +113,10 @@ body {
   line-height: 1.6;
 }
 
+.google-btn-override * {
+  font-family: "Plus Jakarta Sans", system-ui, -apple-system, sans-serif !important;
+}
+
 .font-heading {
   font-family: "Space Grotesk", system-ui, sans-serif;
   letter-spacing: -0.03em;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -142,7 +142,7 @@ export default function LoginPage() {
           </div>
 
           {}
-          <div className="flex justify-center">
+          <div className="flex justify-center google-btn-override">
             <GoogleLogin
               onSuccess={handleGoogleSuccess}
               onError={handleGoogleError}

--- a/frontend/src/pages/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage.tsx
@@ -262,7 +262,7 @@ export default function SignUpPage() {
           </div>
 
           {}
-          <div className="flex justify-center">
+          <div className="flex justify-center google-btn-override">
             <GoogleLogin
               onSuccess={handleGoogleSuccess}
               onError={handleGoogleError}


### PR DESCRIPTION
Add a CSS override to force the app font ("Plus Jakarta Sans") inside Google OAuth buttons and apply the override wrapper to Login and SignUp pages. Also add the text-sm class to the Sign In / Sign Up header buttons for consistent typography. Updated files: frontend/src/components/header.tsx, frontend/src/index.css, frontend/src/pages/LoginPage.tsx, frontend/src/pages/SignUpPage.tsx.