### PR TITLE
fix(auth): return 401 for Google-only accounts on email login

### DIFF
--- a/backend/models/auth.py
+++ b/backend/models/auth.py
@@ -213,6 +213,12 @@ async def login(user_credentials: UserLogin):
             detail="Incorrect email or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
+    if not user.get("hashed_password"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="This account uses Google sign-in. Please sign in with Google.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     if not verify_password(user_credentials.password, user["hashed_password"]):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
## Summary

- Fixes an unhandled `KeyError` crash (HTTP 500) when a user with a Google OAuth account attempts to sign in with email/password
- Google OAuth accounts have no `hashed_password` field; accessing it directly raised an unhandled exception
- Now returns a proper HTTP 401 with the message: *"This account uses Google sign-in. Please sign in with Google."*

## Test plan

- [ ] Create an account via Google OAuth
- [ ] Try to sign in with email/password using the same email — should now see a clear 401 error message instead of "Login failed (HTTP 500)"
- [ ] Sign in with email/password on a normally registered account — should still work as expected