### PR TITLE
fix(deps): remove websockets pin that blocked Vercel deployment

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -27,14 +27,11 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.32.0
 google-auth==2.35.0
+google-auth-oauthlib==1.2.1
+google-auth-httplib2==0.2.0
 httpx==0.27.0
 slowapi==0.1.9
 bleach==6.1.0
 watchfiles==1.1.1
-websockets==16.0
-google-auth==2.35.0
-google-auth-oauthlib==1.2.1
-google-auth-httplib2==0.2.0
-httpx==0.27.0
 supabase==2.7.4
 stripe>=11.0.0,<12.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 uvicorn==0.32.0
 watchfiles==1.1.1
-websockets==16.0
 google-auth==2.35.0
 httpx==0.27.0
 slowapi==0.1.9


### PR DESCRIPTION
## Summary

- Removes the `websockets==16.0` pin from both `requirements.txt` and `api/requirements.txt` — it conflicted with `supabase==2.7.4`'s transitive `realtime` dependency, causing `uv lock` to fail with "no solution found when resolving dependencies" during Vercel builds
- Deduplicates `google-auth` and `httpx` entries that were accidentally doubled in `api/requirements.txt`

## Test plan

- [ ] Vercel deployment completes without dependency resolution errors
- [ ] Backend API routes function normally (supabase client initializes correctly)