### PR TITLE
fix(frontend): remove unused navigate in page.tsx

### DIFF
--- a/frontend/src/page.tsx
+++ b/frontend/src/page.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "react-router-dom"
 import { Button } from "@/components/ui/button"
 import {
   ChevronLeft, ChevronRight, Mail
@@ -9,8 +8,6 @@ import { FeatureShowcase } from "@/components/FeatureShowcase"
 
 
 export default function HomePage() {
-  const navigate = useNavigate()
-
   const [testimonialIndex, setTestimonialIndex] = useState(0)
   const [email, setEmail] = useState("")
 


### PR DESCRIPTION
## Summary
- Removes unused `navigate` variable and `useNavigate` import from `src/page.tsx`
- Fixes `TS6133: 'navigate' is declared but its value is never read` that was breaking the Vercel build

## Test plan
- [x] Verify `npm run build` in `/frontend` completes without TypeScript errors