### PR TITLE
fix(deploy): build frontend on Vercel instead of serving gitignored dist

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,30 +1,10 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "frontend/package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    },
-    {
-      "src": "api/index.py",
-      "use": "@vercel/python"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/index.py"
-    },
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
+  "buildCommand": "cd frontend && npm install && npm run build",
+  "outputDirectory": "frontend/dist",
+  "framework": null,
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/index.py" },
+    { "source": "/:path*", "destination": "/index.html" }
   ],
   "headers": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,11 @@
   "version": 2,
   "builds": [
     {
-      "src": "frontend/dist/**",
-      "use": "@vercel/static"
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
     },
     {
       "src": "api/index.py",
@@ -16,8 +19,11 @@
       "dest": "/api/index.py"
     },
     {
+      "handle": "filesystem"
+    },
+    {
       "src": "/(.*)",
-      "dest": "/frontend/dist/$1"
+      "dest": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
## What changed

- `vercel.json`: replaced `@vercel/static` (pointing at `frontend/dist/**`) with `@vercel/static-build` (pointing at `frontend/package.json`)
- Added `"config": { "distDir": "dist" }` so Vercel knows where Vite outputs its build
- Replaced broken `/frontend/dist/$1` static route with `{ "handle": "filesystem" }` + `/index.html` SPA fallback

## Why

`frontend/dist/` is gitignored, so it never exists in the Vercel build environment. The old config used `@vercel/static`, which only serves pre-existing files — it never ran a build step, so every request 404'd at the Vercel routing layer.

`@vercel/static-build` triggers the `vercel-build` npm script (already defined in `frontend/package.json` as `npm run build`), producing the dist at deploy time.

The SPA fallback route is also required so React Router can handle client-side navigation without hitting 404s on direct URL loads.

## Reviewer notes

No code logic changed — only the Vercel deployment config.