### PR TITLE
perf(api): default DEMO_MODE to false to prevent cold-start seed

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -13,9 +13,9 @@ import os
 import sys
 from pathlib import Path
 
-# Enable demo mode in Vercel when no production database is configured,
-# preventing cold-start crashes from missing MongoDB/Supabase credentials.
-os.environ.setdefault("DEMO_MODE", "true")
+# Demo mode is opt-in. Set DEMO_MODE=true in Vercel env vars explicitly;
+# defaulting to true caused seed_demo_dataset to run on every cold start.
+os.environ.setdefault("DEMO_MODE", "false")
 
 # Set a default SECRET_KEY for JWT signing in serverless demo mode.
 # In production, this should be set via environment variables.


### PR DESCRIPTION
## Summary

- Changes `DEMO_MODE` default in `api/index.py` from `"true"` to `"false"`
- Demo mode is now opt-in: set `DEMO_MODE=true` explicitly in Vercel environment variables when needed
- Prevents `seed_demo_dataset` from running on every cold start in production

## Test plan

- [ ] Verify production deployment still serves real data (Supabase env vars must be set)
- [ ] Verify local dev with `DEMO_MODE=true` still seeds demo data correctly
- [ ] Confirm cold starts no longer trigger unnecessary seeding