### PR TITLE
chore(ci): add Dependabot auto-merge and branch protection

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

- Enabled branch protection on `main` requiring the `validate` CI job to pass before merging
- Added `.github/workflows/dependabot-auto-merge.yml` — a workflow that enables auto-merge (merge commit) on all Dependabot PRs as soon as they open

## Why

Dependabot PRs were piling up and needed manual merging. With branch protection gating on CI and auto-merge enabled, Dependabot PRs will merge automatically once the build goes green — no manual intervention needed.

## Reviewer notes

- Branch protection was applied directly via the GitHub API (not in-repo config), so it's already live on `main`
- Auto-merge uses the merge commit strategy; change `--merge` to `--squash` in the workflow if squash is preferred