### PR TITLE
chore(ci): add Gemini Code Assist config for automated PR reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,13 @@
+code_review:
+  # Automatically review every pull request
+  comment_on_pull_requests: true
+
+  # Keep responses concise and actionable
+  max_review_comments: 10
+
+  # Focus areas for review
+  checks:
+    - bugs
+    - security
+    - performance
+    - best_practices


### PR DESCRIPTION
## What changed

Adds `.gemini/config.yaml` to enable Gemini Code Assist automated PR reviews.

## Why

Provides free, automated code review on every pull request using the Gemini Code Assist GitHub App (free tier). Reviews cover bugs, security, performance, and best practices with a cap of 10 comments per PR to keep feedback focused.

## Reviewer notes

This config only takes effect once the **Gemini Code Assist GitHub App** is installed on the repository via the GitHub Marketplace (free plan). The app install is a one-time manual step outside of this PR.