### PR TITLE
ci(dependabot): fix auto-merge job showing as failed on non-Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,9 +9,9 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge
+        if: ${{ github.actor == 'dependabot[bot]' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What changed

Moved the `github.actor == 'dependabot[bot]'` condition from the **job** level to the **step** level in `.github/workflows/dependabot-auto-merge.yml`.

## Why

When the condition was on the job, GitHub skipped the entire job for non-Dependabot PRs. If this job is listed as a required status check, a skipped job appears as a failure (red ✗) on every human-authored PR.

Moving the condition to the step means the job always runs and always exits green — the merge step is simply a no-op for non-Dependabot actors.

## Before / After

**Before:** job skipped → shows as failed on every non-Dependabot PR  
**After:** job runs, step skipped → shows as passed on every PR