### PR TITLE
fix(auth): propagate Supabase errors on login instead of masking as invalid credentials

### DIFF
--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -99,7 +99,7 @@ async fn login(
         .supabase
         .auth_login_password(&email, &payload.password)
         .await
-        .map_err(|_| AppError::Unauthorized("Invalid credentials".into()))?;
+        .map_err(map_supabase_auth_error)?;
     let user = ensure_auth_defaults(&state, session.user.clone(), None, Some("email")).await?;
 
     Ok((


### PR DESCRIPTION
## What

The login handler was swallowing all Supabase errors with a blanket `|_| AppError::Unauthorized("Invalid credentials")`, which meant any backend failure — including a paused/unavailable Supabase project — surfaced to the user as "Invalid credentials."

Switch to `map_supabase_auth_error`, the same helper already used on every other auth path, so:
- Wrong password → 401 "Invalid credentials" (unchanged behaviour)  
- Supabase paused / network error → 500 "Authentication service unavailable" (correct and debuggable)

## Why

The Supabase `vantage` project was auto-paused (INACTIVE), causing all login attempts to fail silently with a misleading error. The masked error made this invisible in both Vercel runtime logs and user-facing messages.

The Supabase project has been manually restored. This fix prevents a future pause from being indistinguishable from bad credentials.

## Testing

- Valid credentials while Supabase is healthy → logs in normally  
- Invalid credentials → 401 "Invalid credentials"  
- Supabase unavailable → 500 "Authentication service unavailable" (previously also 401 "Invalid credentials")