### PR TITLE
security: harden rate limiting, response headers, and realtime reconnect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Authoritative migrations are applied in order:
 scripts/supabase/migrations/202605180001_supabase_single_source.sql
 scripts/supabase/migrations/202605200001_postgis_geo_queries.sql
 scripts/supabase/migrations/202605200002_review_summary_rpc.sql
+scripts/supabase/migrations/202605200003_deal_status_consistency.sql
 ```
 
 Protected backend routes verify Supabase-signed access tokens from httpOnly

--- a/PRD.md
+++ b/PRD.md
@@ -4,8 +4,8 @@
 
 | Field | Value |
 |---|---|
-| Version | v2.1 — Supabase + Production Hardening Baseline |
-| Last Updated | May 21, 2026 |
+| Version | v2.2 — Deep Backend Audit Pass |
+| Last Updated | June 11, 2026 |
 | Stack | React 19 / TypeScript / Vite / Rust Axum / Supabase / Vercel |
 
 ## 1. Product Vision
@@ -147,9 +147,22 @@ Current Rust implementation computes a 0-100 score from:
 - Verified status
 - Description presence
 - Photo presence
-- Stored positive score override
 
 `is_claimed` and `owner_id` are intentionally excluded.
+
+**Known invariant violation (unfixed):** `visibility_score.rs` lines 15–18 return
+any stored `visibility_score > 0` verbatim before computing organic signals. A
+single non-zero value written to the DB permanently freezes that business's
+ranking. The stored-override path must be removed or gated behind an explicit
+admin override flag.
+
+**Known deceptive advertising (unfixed):** `SubscriptionTier::visibility_boost()`
+and `featured_placement()` return `true` for PRO/PREMIUM and are surfaced in the
+`/subscriptions/tiers` response, but `visibility_score::compute()` never reads
+them. Paid subscribers are promised ranking benefits that do not exist. Either
+remove the flags from `TierInfo`, or honour them in the scoring function without
+violating the LVS invariant (e.g. as a tie-breaker after organic score, never
+boosting above organic score).
 
 Business owners cannot create or update reviews for their own listings, because
 rating and review-count signals contribute to discovery trust and visibility.
@@ -332,30 +345,140 @@ Completed in the current baseline:
   `cd frontend && npm run lint`, `cd frontend && npm run build`,
   `npm audit --audit-level=high`.
 
-Known limitations:
+Known limitations and open bugs (June 2026 audit pass):
 
-- Supabase migration has been authored but not applied from this session.
-- There are only focused backend route/unit tests so far; full integration tests
-  are still needed for auth guards, owner checks, saved businesses, reviews,
-  check-ins, subscriptions, and activity flows.
-- Stripe webhook code is implemented, but live webhook delivery still needs to
-  be smoke-tested against the deployed `/api/stripe/webhook` endpoint.
-- PostGIS radius RPCs have been authored and wired into the backend, but the
-  target Supabase project still needs the migration applied and smoke-tested.
-- Realtime is enabled at the database publication level, but the frontend still
-  polls/fetches instead of subscribing to Supabase realtime channels.
-- `npx vercel build` could not be verified locally because the checkout does not
-  have linked Vercel project settings. Run `vercel pull` or configure local
-  project settings before repeating that gate.
+**Broken by default (data correctness):**
+
+- All domain model structs (`Business`, `User`, `Review`, `Subscription`,
+  `ActivityFeedItem`, `CheckIn`, `OwnerPost`, `BusinessClaim`, `Deal`,
+  `SavedRecord`) have `#[serde(rename = "_id")]` on `id`. Supabase columns are
+  named `id`, not `_id`. These structs fail to deserialize DB rows; `id` is
+  always `None` when these types are used directly. The `normalize_id_alias`
+  helper in `routes/support.rs` patches this only in JSON-blob paths.
+- `create_business` sets `owner_id: auth_user.id` and `is_claimed: false`
+  simultaneously. `ensure_business_open_for_claim_submission` blocks claims when
+  `owner_id` is non-null. Owner-created listings can never be formally claimed.
+- `SubscriptionTier::max_deals()` defines per-tier deal limits that are never
+  enforced in `routes/deals.rs`. Free-tier businesses can create unlimited deals.
+
+**Security (unfixed):**
+
+- `middleware/auth.rs:121–122`: Session cookie overwrites an already-extracted
+  Bearer token. A valid `Authorization: Bearer` header is discarded if a stale
+  `session=` cookie is also present.
+- `middleware/rate_limit.rs:51`: `X-Forwarded-For` uses the leftmost
+  (client-controlled) IP via `.split(',').next()`. Rate limiting is trivially
+  bypassed by prepending a spoofed IP.
+- `middleware/security_headers.rs:25`: `is_localhost` is derived from the
+  client-supplied `Host` header. Sending `Host: localhost` bypasses all security
+  headers in production.
+- `config.rs`: Dev origins (`http://localhost:5173`, `:3000`, `:5174`) and all
+  Vercel preview `VERCEL_URL` values are included in the CORS allowlist
+  unconditionally, combined with `allow_credentials(true)`.
+- `routes/auth.rs`: Logout clears cookies but never calls Supabase token
+  revocation. A stolen refresh token stays valid for up to 7 days.
+- `jwt.rs`: `nbf` (not-before) claim is never verified. A token with a future
+  `nbf` is accepted immediately.
+
+**Race conditions (unfixed):**
+
+- `reviews.rs`: `create_review` duplicate-check and insert are two separate DB
+  calls (TOCTOU). Concurrent requests both see no duplicate and both insert.
+- `subscriptions.rs:415–521`: Stripe webhook activation is a non-atomic 4-step
+  sequence. Duplicate at-least-once webhook deliveries create two active
+  subscriptions.
+- `saved.rs:77–102`: `save_business` checks then inserts in two separate calls.
+  Concurrent saves create duplicate saved records.
+- `claims.rs:168–215`: Already-approved claims can be re-reviewed. Claim
+  approval is a non-atomic read+write.
+
+**Performance / resource (unfixed):**
+
+- `saved.rs:43–57`: `list_saved` calls `select_one_json` per saved business (N+1
+  round-trips). No pagination limit on the initial `saved_businesses` query.
+- `activity.rs:438–480`: `get_activity_pulse` calls `find_business` inside a
+  loop — up to 90 sequential DB round-trips per request.
+- `activity.rs:651–673`: `list_owner_events` calls `find_business` per event —
+  up to 100 sequential round-trips.
+- `stripe.rs`, `google_places.rs`, `recaptcha.rs`: New `reqwest::Client` per
+  call. TLS connection pooling is completely defeated. All three services should
+  use a shared client stored in `AppState`.
+
+**Behaviour bugs (unfixed):**
+
+- `discovery.rs:150+163`: `/decide` always returns exactly 5 results regardless
+  of the `limit` parameter. The over-fetch multiplier corrupts the truncation
+  target.
+- `discovery.rs:118–139`: `/explore/lanes` inherits `q`/`search` from the caller.
+  A request with `?q=keyword` distorts all 5 curated lanes with the user's search.
+- `location.rs:49`: Any Google geocoding API error (rate limit, auth, network)
+  returns 400 Bad Request, misleading clients into thinking their coordinates
+  were invalid.
+- `models/deal.rs`: `DealUpdate` has no `#[derive(Validate)]`. Update requests
+  can set `title` to empty or `discount_percent` to `999.0`.
+- `models/business.rs`: `BusinessUpdate` has no `#[derive(Validate)]`. Name and
+  address are unconstrained on update. `BusinessCreate.address` has no max
+  length.
+
+**Migration / deployment (unchanged):**
+
+- Supabase migration has been authored but not applied to the live project.
+- Full integration tests for auth guards, owner checks, saved businesses,
+  reviews, check-ins, subscriptions, and activity flows are still needed.
+- Stripe webhook delivery needs smoke-testing against the deployed endpoint.
+- PostGIS RPCs need migration applied and smoke-tested.
+- Frontend still polls rather than subscribing to Supabase Realtime channels.
+- `npx vercel build` cannot be verified locally without linked Vercel project
+  settings.
 
 ## 9. Next Priorities
 
-1. Apply the Supabase migrations in the target project and verify
-   table/storage/PostGIS RPC permissions with real anon/authenticated/service-role
-   requests.
-2. Add backend integration tests for all protected route families.
-3. Add fraud-resistant moderation for review/check-in abuse and coordinated
-   engagement.
-4. Add frontend realtime subscriptions for activity feed, comments, and events.
-5. Add deployment smoke tests for `/api/health`, `/api/discover`,
-   `/api/stripe/webhook`, `/api/auth/me`, and SPA fallback routes.
+**P0 — Must fix before production launch:**
+
+1. Remove `#[serde(rename = "_id")]` from all model structs and replace with
+   `#[serde(rename = "id")]` or plain `pub id`, so Supabase rows deserialize
+   correctly.
+2. Fix `create_business`: either set `owner_id` but also set `is_claimed: true`,
+   or clear `owner_id` and let the claims workflow handle ownership. Currently
+   owner-created listings are in an unclaimable limbo state.
+3. Remove the stored-override early-return from `visibility_score::compute()`.
+   If admin overrides are needed, model them as an explicit flag separate from
+   the organic LVS.
+4. Fix `X-Forwarded-For` IP extraction to use the rightmost trusted IP, not the
+   leftmost client-controlled one.
+5. Fix `is_localhost` to use the server's configured origin list, not the
+   client-supplied `Host` header.
+6. Enforce `max_deals()` in `create_deal` — read the business's active
+   subscription tier and reject requests that exceed the tier limit.
+
+**P1 — Fix before exposing paid features:**
+
+7. Remove or rename `visibility_boost`/`featured_placement` from `TierInfo` until
+   they are actually wired into the scoring function.
+8. Replace the 4-step non-atomic Stripe webhook activation with a single
+   conditional upsert or idempotency key check.
+9. Add Stripe token revocation to the logout path.
+10. Add `nbf` check to `jwt.rs::parse_claims`.
+11. Fix `middleware/auth.rs:121–122` cookie-overwrites-Bearer bug.
+
+**P2 — Stability and performance:**
+
+12. Batch-fetch businesses in `list_saved` instead of N+1 round-trips.
+13. Batch-fetch businesses in `get_activity_pulse` and `list_owner_events`.
+14. Move `reqwest::Client` construction out of per-call functions and into
+    `AppState` for Stripe, Google Places, and reCAPTCHA.
+15. Fix `/decide` limit truncation — preserve original limit through the
+    over-fetch multiplier.
+16. Add `#[derive(Validate)]` and constraints to `DealUpdate` and `BusinessUpdate`.
+17. Guard CORS dev origins behind an environment check.
+
+**P3 — Integration and deployment:**
+
+18. Apply the Supabase migrations and verify table/storage/PostGIS RPC
+    permissions with real anon/authenticated/service-role requests.
+19. Add backend integration tests for all protected route families.
+20. Add fraud-resistant moderation for review/check-in abuse and coordinated
+    engagement.
+21. Add frontend realtime subscriptions for activity feed, comments, and events.
+22. Add deployment smoke tests for `/api/health`, `/api/discover`,
+    `/api/stripe/webhook`, `/api/auth/me`, and SPA fallback routes.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ scripts/supabase/migrations/202605200003_deal_status_consistency.sql
   do not expose bearer tokens to frontend JavaScript.
 - Google sign-in requires the Google provider to be enabled in Supabase Auth;
   the frontend still needs `VITE_GOOGLE_CLIENT_ID` for the Google button.
+- Frontend realtime updates for feed items, comments, and owner events require
+  `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`; without them, the app falls
+  back to ordinary API polling/loading behavior.
 - Business, discovery, activity, saved businesses, claims, deals, reviews, and subscriptions use Supabase PostgREST through the Rust API.
 - Subscription cancellation is business-scoped when needed and auth
   subscription metadata is recomputed from the user's highest active business
@@ -117,8 +120,10 @@ scripts/supabase/migrations/202605200003_deal_status_consistency.sql
 ## Next Steps
 
 - Consolidate repeated frontend view helpers into shared utilities.
-- Add route-level backend tests for ranking, auth guards, and saved/check-in flows.
-- Add stronger moderation tooling for fake reviews and coordinated engagement.
+- Run live Supabase migration and realtime smoke tests against the target
+  project.
+- Add stronger moderation tooling beyond the current baseline abuse guards for
+  fake reviews and coordinated engagement.
 - Smoke-test signed Stripe webhook delivery against the deployed
   `/api/stripe/webhook` endpoint.
 - Link or pull Vercel project settings locally before rerunning `npx vercel build`.

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -136,17 +136,27 @@ impl Config {
 
     pub fn allowed_origins(&self) -> Vec<String> {
         let mut origins = Vec::new();
-        push_origin(&mut origins, "http://localhost:5173");
-        push_origin(&mut origins, "http://localhost:3000");
-        push_origin(&mut origins, "http://localhost:5174");
-        push_origin(&mut origins, &self.frontend_url);
-        push_origin(&mut origins, &self.production_url);
+        if self.is_production() {
+            if !self.production_url.trim().is_empty() {
+                push_origin(&mut origins, &self.production_url);
+            } else {
+                push_origin(&mut origins, &self.frontend_url);
+            }
+        } else {
+            push_origin(&mut origins, "http://localhost:5173");
+            push_origin(&mut origins, "http://localhost:3000");
+            push_origin(&mut origins, "http://localhost:5174");
+            push_origin(&mut origins, &self.frontend_url);
+            push_origin(&mut origins, &self.production_url);
+        }
 
-        if let Ok(vercel_url) = env::var("VERCEL_URL") {
-            push_origin(
-                &mut origins,
-                format!("https://{}", vercel_url.trim_start_matches("https://")),
-            );
+        if !self.is_production() {
+            if let Ok(vercel_url) = env::var("VERCEL_URL") {
+                push_origin(
+                    &mut origins,
+                    format!("https://{}", vercel_url.trim_start_matches("https://")),
+                );
+            }
         }
         origins
     }
@@ -263,5 +273,13 @@ mod tests {
 
         config.stripe_webhook_secret = "whsec_test".into();
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn production_cors_does_not_include_dev_origins() {
+        let origins = config("production", "https://vantage.example", "").allowed_origins();
+
+        assert!(!origins.contains(&"http://localhost:5173".to_string()));
+        assert_eq!(origins, vec!["https://vantage.example".to_string()]);
     }
 }

--- a/backend/src/db/supabase.rs
+++ b/backend/src/db/supabase.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 /// How long a fetched JWKS set is treated as fresh before refetching.
 const JWKS_TTL: Duration = Duration::from_secs(600);
@@ -45,6 +45,7 @@ pub struct SupabaseClient {
     pub service_role_key: String,
     pub http: Client,
     jwks: Arc<RwLock<JwksCache>>,
+    jwks_refresh: Arc<Mutex<()>>,
 }
 
 impl SupabaseClient {
@@ -59,6 +60,7 @@ impl SupabaseClient {
             service_role_key: config.supabase_service_role_key.clone(),
             http,
             jwks: Arc::new(RwLock::new(JwksCache::default())),
+            jwks_refresh: Arc::new(Mutex::new(())),
         }
     }
 
@@ -88,8 +90,8 @@ impl SupabaseClient {
 
     async fn refresh_jwks(&self) -> Result<()> {
         self.ensure_configured()?;
-        // Throttle network fetches so unknown-kid lookups can't trigger one
-        // request per call.
+        let _refresh_guard = self.jwks_refresh.lock().await;
+
         {
             let cache = self.jwks.read().await;
             if let Some(at) = cache.fetched_at {
@@ -344,8 +346,12 @@ impl SupabaseClient {
         table: &str,
         query: &[(&str, &str)],
     ) -> Result<Option<T>> {
-        let mut results = self.select::<T>(table, query).await?;
-        Ok(results.pop())
+        let mut scoped = query.to_vec();
+        if !scoped.iter().any(|(key, _)| *key == "limit") {
+            scoped.push(("limit", "1"));
+        }
+        let results = self.select::<T>(table, &scoped).await?;
+        Ok(results.into_iter().next())
     }
 
     pub async fn insert<B: Serialize, T: DeserializeOwned>(
@@ -549,6 +555,20 @@ impl SupabaseClient {
             .delete(&url)
             .header("apikey", &self.service_role_key)
             .header("Authorization", format!("Bearer {}", self.service_role_key))
+            .send()
+            .await?;
+        Self::parse_json_response(resp).await?;
+        Ok(())
+    }
+
+    pub async fn auth_logout(&self, access_token: &str) -> Result<()> {
+        self.ensure_configured()?;
+        let url = format!("{}/auth/v1/logout?scope=global", self.url);
+        let resp = self
+            .http
+            .post(&url)
+            .header("apikey", &self.service_role_key)
+            .header("Authorization", format!("Bearer {}", access_token))
             .send()
             .await?;
         Self::parse_json_response(resp).await?;

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -11,6 +11,9 @@ pub enum AppError {
     #[error("Database unavailable: {0}")]
     DatabaseUnavailable(String),
 
+    #[error("Service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     #[error("Not found: {0}")]
     NotFound(String),
 
@@ -39,7 +42,12 @@ impl IntoResponse for AppError {
             AppError::DatabaseUnavailable(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "database_unavailable",
-                msg.as_str(),
+                public_5xx_message(msg, "Database temporarily unavailable"),
+            ),
+            AppError::ServiceUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "service_unavailable",
+                public_5xx_message(msg, "Service temporarily unavailable"),
             ),
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, "not_found", msg.as_str()),
             AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, "unauthorized", msg.as_str()),
@@ -49,7 +57,7 @@ impl IntoResponse for AppError {
             AppError::Internal(msg) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_error",
-                msg.as_str(),
+                public_5xx_message(msg, "Internal server error"),
             ),
             AppError::RateLimited => (
                 StatusCode::TOO_MANY_REQUESTS,
@@ -66,12 +74,18 @@ impl IntoResponse for AppError {
 impl From<anyhow::Error> for AppError {
     fn from(e: anyhow::Error) -> Self {
         let message = e.to_string();
+        tracing::error!(error = %message, "Internal backend error");
         if message.to_ascii_lowercase().contains("supabase") {
-            AppError::DatabaseUnavailable(message)
+            AppError::DatabaseUnavailable("Database temporarily unavailable".into())
         } else {
-            AppError::Internal(message)
+            AppError::Internal("Internal server error".into())
         }
     }
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;
+
+fn public_5xx_message<'a>(msg: &'a str, fallback: &'static str) -> &'a str {
+    tracing::error!(error = %msg, "Returning sanitized server error");
+    fallback
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -31,11 +31,7 @@ pub async fn build_app() -> anyhow::Result<Router> {
     let config = Config::from_env();
     config.validate()?;
     let db = Database::new(&config).await;
-    let state = Arc::new(AppState {
-        config: config.clone(),
-        db,
-        rate_limiter: security::RateLimiter::new(),
-    });
+    let state = Arc::new(AppState::new(config.clone(), db)?);
 
     Ok(build_router(state))
 }
@@ -126,9 +122,15 @@ mod tests {
     use super::*;
     use axum::{
         body::Body,
-        http::{Request, StatusCode},
+        http::{header, Method, Request, StatusCode},
     };
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use hmac::{Hmac, Mac};
+    use serde_json::{json, Value};
+    use sha2::Sha256;
     use tower::ServiceExt;
+
+    type HmacSha256 = Hmac<Sha256>;
 
     fn test_config() -> Config {
         Config {
@@ -145,7 +147,7 @@ mod tests {
             production_url: String::new(),
             environment: "test".into(),
             rate_limit_per_minute: 120,
-            supabase_url: "https://example.supabase.co".into(),
+            supabase_url: String::new(),
             supabase_service_role_key: "test-service-role-key".into(),
             supabase_jwt_secret: "test-supabase-jwt-secret".into(),
             stripe_secret_key: String::new(),
@@ -158,13 +160,10 @@ mod tests {
 
     fn test_state() -> Arc<AppState> {
         let config = test_config();
-        Arc::new(AppState {
-            db: Database {
-                supabase: db::SupabaseClient::new(&config),
-            },
-            config,
-            rate_limiter: security::RateLimiter::new(),
-        })
+        let db = Database {
+            supabase: db::SupabaseClient::new(&config),
+        };
+        Arc::new(AppState::new(config, db).unwrap())
     }
 
     #[test]
@@ -215,5 +214,170 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn protected_routes_require_authentication_before_database() {
+        let cases = [
+            (Method::GET, "/api/auth/me", Value::Null),
+            (Method::GET, "/api/saved", Value::Null),
+            (Method::GET, "/api/subscriptions/my", Value::Null),
+            (Method::POST, "/api/reviews", json!({})),
+            (Method::POST, "/api/checkins", json!({})),
+            (Method::POST, "/api/feed/posts", json!({})),
+            (
+                Method::POST,
+                "/api/feed/550e8400-e29b-41d4-a716-446655440000/like",
+                Value::Null,
+            ),
+        ];
+
+        for (method, uri, body) in cases {
+            let response = send(method, uri, body, None).await;
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn owner_only_routes_reject_customer_tokens_before_database() {
+        let customer = hs256_token("550e8400-e29b-41d4-a716-446655440000", "customer");
+        let business_id = "660e8400-e29b-41d4-a716-446655440000";
+        let cases = [
+            (
+                Method::POST,
+                "/api/businesses",
+                json!({
+                    "name": "Test Shop",
+                    "address": "1 Main St",
+                    "category": "restaurant"
+                }),
+            ),
+            (
+                Method::POST,
+                "/api/subscriptions",
+                json!({
+                    "business_id": business_id,
+                    "tier": "free",
+                    "billing_cycle": "monthly"
+                }),
+            ),
+            (
+                Method::POST,
+                "/api/claims",
+                json!({
+                    "business_id": business_id,
+                    "owner_name": "Test Owner"
+                }),
+            ),
+        ];
+
+        for (method, uri, body) in cases {
+            let response = send(method, uri, body, Some(&customer)).await;
+            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_route_contracts_return_bad_request_before_database() {
+        let customer = hs256_token("550e8400-e29b-41d4-a716-446655440000", "customer");
+        let business_id = "660e8400-e29b-41d4-a716-446655440000";
+        let cases = [
+            (Method::POST, "/api/checkins", json!({})),
+            (
+                Method::POST,
+                "/api/reviews",
+                json!({ "business_id": business_id, "rating": 6 }),
+            ),
+            (Method::POST, "/api/saved/not-a-uuid", Value::Null),
+            (Method::POST, "/api/feed/posts", json!({ "content": "   " })),
+            (Method::POST, "/api/feed/not-a-uuid/like", Value::Null),
+        ];
+
+        for (method, uri, body) in cases {
+            let response = send(method, uri, body, Some(&customer)).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn deployment_smoke_routes_fail_safely_without_external_services() {
+        let health = send(Method::GET, "/api/health", Value::Null, None).await;
+        assert_eq!(health.status(), StatusCode::OK);
+
+        let discover = send(
+            Method::GET,
+            "/api/discover?lat=999&lng=0",
+            Value::Null,
+            None,
+        )
+        .await;
+        assert_eq!(discover.status(), StatusCode::BAD_REQUEST);
+
+        let stripe_webhook = send(
+            Method::POST,
+            "/api/stripe/webhook",
+            json!({ "id": "evt_test" }),
+            None,
+        )
+        .await;
+        assert_eq!(stripe_webhook.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn vercel_rewrites_cover_api_and_spa_fallback() {
+        let config: Value =
+            serde_json::from_str(include_str!("../../vercel.json")).expect("valid vercel.json");
+        let rewrites = config["rewrites"].as_array().expect("rewrites array");
+
+        assert!(rewrites.iter().any(|rewrite| {
+            rewrite["source"] == "/api/:path*" && rewrite["destination"] == "/api/index"
+        }));
+        assert!(rewrites.iter().any(|rewrite| {
+            rewrite["source"] == "/:path*" && rewrite["destination"] == "/index.html"
+        }));
+    }
+
+    async fn send(
+        method: Method,
+        uri: &str,
+        body: Value,
+        bearer_token: Option<&str>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = bearer_token {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {}", token));
+        }
+        let request = if body.is_null() {
+            builder.body(Body::empty()).unwrap()
+        } else {
+            builder
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap()
+        };
+
+        build_router(test_state()).oneshot(request).await.unwrap()
+    }
+
+    fn hs256_token(user_id: &str, role: &str) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(
+            json!({
+                "sub": user_id,
+                "email": "test@example.com",
+                "exp": chrono::Utc::now().timestamp() + 300,
+                "iat": chrono::Utc::now().timestamp(),
+                "app_metadata": { "role": role },
+                "user_metadata": { "full_name": "Test User" }
+            })
+            .to_string()
+            .as_bytes(),
+        );
+        let signing_input = format!("{}.{}", header, payload);
+        let mut mac = HmacSha256::new_from_slice(test_config().supabase_jwt_secret.as_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(signing_input.as_bytes());
+        let signature = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+        format!("{}.{}", signing_input, signature)
     }
 }

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -3,7 +3,7 @@ use crate::{
     models::user::SupabaseJwtClaims, security, state::AppState,
 };
 use async_trait::async_trait;
-use axum::http::HeaderValue;
+use axum::http::{HeaderMap, HeaderValue};
 use axum::{
     body::Body,
     extract::{FromRequestParts, Request, State},
@@ -74,6 +74,10 @@ pub async fn optional_auth(
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
+    if req.uri().path() == "/api/auth/logout" {
+        return next.run(req).await;
+    }
+
     let tokens = extract_tokens(&req);
     let refreshed = if tokens.access_token.is_some() || tokens.refresh_token.is_some() {
         match authenticate_tokens(&state, tokens).await {
@@ -119,7 +123,9 @@ fn extract_tokens(req: &Request<Body>) -> RequestTokens {
         for part in cookie_header.split(';') {
             let part = part.trim();
             if let Some(value) = part.strip_prefix("session=") {
-                tokens.access_token = Some(value.to_string());
+                if tokens.access_token.is_none() {
+                    tokens.access_token = Some(value.to_string());
+                }
             } else if let Some(value) = part.strip_prefix("refresh_token=") {
                 tokens.refresh_token = Some(value.to_string());
             }
@@ -127,6 +133,29 @@ fn extract_tokens(req: &Request<Body>) -> RequestTokens {
     }
 
     tokens
+}
+
+pub fn access_token_from_headers(headers: &HeaderMap) -> Option<String> {
+    if let Some(token) = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(token.to_string());
+    }
+
+    headers
+        .get(COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|cookie_header| {
+            cookie_header.split(';').find_map(|part| {
+                part.trim()
+                    .strip_prefix("session=")
+                    .filter(|value| !value.trim().is_empty())
+                    .map(str::to_string)
+            })
+        })
 }
 
 async fn authenticate_tokens(

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -43,18 +43,81 @@ fn auth_sensitive_limit(path: &str, default_limit: u32) -> u32 {
 }
 
 fn client_key(req: &Request<Body>) -> String {
-    for name in ["cf-connecting-ip", "x-real-ip", "x-forwarded-for"] {
-        if let Some(value) = req
-            .headers()
-            .get(HeaderName::from_static(name))
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.split(',').next())
-            .map(str::trim)
-            .filter(|v| !v.is_empty())
-        {
-            return value.chars().take(64).collect();
-        }
+    // x-real-ip is set by trusted infrastructure (nginx, Vercel edge).
+    // cf-connecting-ip is omitted: this app runs on Vercel, not Cloudflare,
+    // so that header is not stripped and can be spoofed by clients.
+    if let Some(value) = header_ip(req, "x-real-ip", HeaderIpPosition::First) {
+        return value;
+    }
+
+    if let Some(value) = header_ip(req, "x-forwarded-for", HeaderIpPosition::Last) {
+        return value;
     }
 
     "unknown-client".to_string()
+}
+
+enum HeaderIpPosition {
+    First,
+    Last,
+}
+
+fn header_ip(
+    req: &Request<Body>,
+    name: &'static str,
+    position: HeaderIpPosition,
+) -> Option<String> {
+    let header = req
+        .headers()
+        .get(HeaderName::from_static(name))
+        .and_then(|value| value.to_str().ok())?;
+    let value = match position {
+        HeaderIpPosition::First => header.split(',').next(),
+        HeaderIpPosition::Last => header.split(',').next_back(),
+    }?
+    .trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.chars().take(64).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::client_key;
+    use axum::{body::Body, http::Request};
+
+    #[test]
+    fn x_forwarded_for_uses_rightmost_ip() {
+        let request = Request::builder()
+            .header("x-forwarded-for", "203.0.113.10, 198.51.100.20")
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(client_key(&request), "198.51.100.20");
+    }
+
+    #[test]
+    fn x_real_ip_takes_precedence_over_forwarded_for() {
+        let request = Request::builder()
+            .header("x-real-ip", "203.0.113.30")
+            .header("x-forwarded-for", "203.0.113.10, 198.51.100.20")
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(client_key(&request), "203.0.113.30");
+    }
+
+    #[test]
+    fn cf_connecting_ip_is_not_trusted_without_cloudflare() {
+        let request = Request::builder()
+            .header("cf-connecting-ip", "1.2.3.4")
+            .header("x-forwarded-for", "203.0.113.10, 198.51.100.20")
+            .body(Body::empty())
+            .unwrap();
+
+        // cf-connecting-ip must not be used: this app runs on Vercel, not
+        // Cloudflare, so the header is spoofable by clients.
+        assert_ne!(client_key(&request), "1.2.3.4");
+    }
 }

--- a/backend/src/middleware/security_headers.rs
+++ b/backend/src/middleware/security_headers.rs
@@ -24,10 +24,7 @@ pub async fn add_security_headers(req: Request<Body>, next: Next) -> Response {
         HeaderValue::from_static("nosniff"),
     );
     headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
-    headers.insert(
-        "X-XSS-Protection",
-        HeaderValue::from_static("0"),
-    );
+    headers.insert("X-XSS-Protection", HeaderValue::from_static("0"));
     headers.insert(
         "Referrer-Policy",
         HeaderValue::from_static("strict-origin-when-cross-origin"),

--- a/backend/src/middleware/security_headers.rs
+++ b/backend/src/middleware/security_headers.rs
@@ -7,105 +7,96 @@ use axum::{
 };
 
 pub async fn add_security_headers(req: Request<Body>, next: Next) -> Response {
-    let host = req
-        .headers()
-        .get("host")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .split(':')
-        .next()
-        .unwrap_or("")
-        .to_string();
-
     let path = req.uri().path().to_string();
     let method = req.method().clone();
 
     let mut response = next.run(req).await;
 
-    let is_localhost = matches!(host.as_str(), "localhost" | "127.0.0.1");
-
-    if !is_localhost {
-        let headers = response.headers_mut();
+    let headers = response.headers_mut();
+    if is_production_env() {
         headers.insert(
             "Strict-Transport-Security",
             HeaderValue::from_static("max-age=31536000; includeSubDomains; preload"),
         );
-        headers.insert(
-            "X-Content-Type-Options",
-            HeaderValue::from_static("nosniff"),
-        );
-        headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
-        headers.insert(
-            "X-XSS-Protection",
-            HeaderValue::from_static("1; mode=block"),
-        );
-        headers.insert(
-            "Referrer-Policy",
-            HeaderValue::from_static("strict-origin-when-cross-origin"),
-        );
-        headers.insert(
-            "Permissions-Policy",
-            HeaderValue::from_static("geolocation=(self), microphone=(), camera=()"),
-        );
+    }
+    headers.insert(
+        "X-Content-Type-Options",
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
+    headers.insert(
+        "X-XSS-Protection",
+        HeaderValue::from_static("0"),
+    );
+    headers.insert(
+        "Referrer-Policy",
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    );
+    headers.insert(
+        "Permissions-Policy",
+        HeaderValue::from_static("geolocation=(self), microphone=(), camera=()"),
+    );
 
-        let content_type = response
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("")
-            .to_string();
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
 
-        let is_html = content_type.starts_with("text/html");
-        let is_docs_path = matches!(path.as_str(), "/docs" | "/redoc" | "/swagger-ui");
+    let is_html = content_type.starts_with("text/html");
+    let is_docs_path = matches!(path.as_str(), "/docs" | "/redoc" | "/swagger-ui");
 
-        if is_html && !is_docs_path {
-            response.headers_mut().insert(
-                "Content-Security-Policy",
-                HeaderValue::from_static(
-                    "default-src 'self'; \
+    if is_html && !is_docs_path {
+        response.headers_mut().insert(
+            "Content-Security-Policy",
+            HeaderValue::from_static(
+                "default-src 'self'; \
                      script-src 'self' 'unsafe-inline' https://accounts.google.com https://www.google.com https://www.gstatic.com; \
                      style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
                      img-src 'self' data: https: blob:; \
                      font-src 'self' https://fonts.gstatic.com; \
-                     connect-src 'self' https://accounts.google.com https://www.google.com https://www.gstatic.com; \
+                     connect-src 'self' https://accounts.google.com https://www.google.com https://www.gstatic.com https://*.supabase.co wss://*.supabase.co; \
                      frame-src https://accounts.google.com https://www.google.com; \
                      form-action 'self'; \
                      frame-ancestors 'none'",
-                ),
-            );
-        }
+            ),
+        );
+    }
 
-        let is_json = content_type.starts_with("application/json");
-        let is_api_path = path.starts_with("/api/");
-        let is_private_api = is_private_api_path(&path);
+    let is_json = content_type.starts_with("application/json");
+    let is_api_path = path.starts_with("/api/");
+    let is_private_api = is_private_api_path(&path);
 
-        if is_json
-            && is_api_path
-            && is_private_api
-            && !response.headers().contains_key("cache-control")
-        {
-            response.headers_mut().insert(
-                "Cache-Control",
-                HeaderValue::from_static("no-store, max-age=0"),
-            );
-        }
+    if is_json && is_api_path && is_private_api && !response.headers().contains_key("cache-control")
+    {
+        response.headers_mut().insert(
+            "Cache-Control",
+            HeaderValue::from_static("no-store, max-age=0"),
+        );
+    }
 
-        if method == Method::GET
-            && is_json
-            && is_api_path
-            && !is_private_api
-            && !response.headers().contains_key("cache-control")
-        {
-            response.headers_mut().insert(
-                "Cache-Control",
-                HeaderValue::from_static(
-                    "public, max-age=30, s-maxage=60, stale-while-revalidate=60",
-                ),
-            );
-        }
+    if method == Method::GET
+        && is_json
+        && is_api_path
+        && !is_private_api
+        && !response.headers().contains_key("cache-control")
+    {
+        response.headers_mut().insert(
+            "Cache-Control",
+            HeaderValue::from_static("public, max-age=30, s-maxage=60, stale-while-revalidate=60"),
+        );
     }
 
     response
+}
+
+fn is_production_env() -> bool {
+    let raw = std::env::var("ENVIRONMENT")
+        .or_else(|_| std::env::var("VERCEL_ENV"))
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    matches!(raw.as_str(), "prod" | "production")
 }
 
 fn is_private_api_path(path: &str) -> bool {

--- a/backend/src/models/activity.rs
+++ b/backend/src/models/activity.rs
@@ -13,7 +13,7 @@ pub enum ActivityType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActivityFeedItem {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub activity_type: ActivityType,
     pub business_id: String,
@@ -27,7 +27,7 @@ pub struct ActivityFeedItem {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckIn {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub business_id: String,
     pub user_id: String,
@@ -46,7 +46,7 @@ pub struct CheckInCreate {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OwnerPost {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub business_id: String,
     pub owner_id: String,

--- a/backend/src/models/business.rs
+++ b/backend/src/models/business.rs
@@ -70,7 +70,7 @@ pub struct BusinessHours {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Business {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub name: String,
     pub category: Option<String>,
@@ -105,7 +105,7 @@ pub struct BusinessCreate {
     #[validate(length(min = 1, max = 200))]
     pub name: String,
     pub category: Option<String>,
-    #[validate(length(min = 1))]
+    #[validate(length(min = 1, max = 300))]
     pub address: String,
     pub city: Option<String>,
     pub state: Option<String>,
@@ -117,16 +117,25 @@ pub struct BusinessCreate {
     pub lng: Option<f64>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct BusinessUpdate {
+    #[validate(length(min = 1, max = 200))]
     pub name: Option<String>,
+    #[validate(length(max = 80))]
     pub category: Option<String>,
+    #[validate(length(min = 1, max = 300))]
     pub address: Option<String>,
+    #[validate(length(max = 120))]
     pub city: Option<String>,
+    #[validate(length(max = 80))]
     pub state: Option<String>,
+    #[validate(length(max = 20))]
     pub zip_code: Option<String>,
+    #[validate(length(max = 40))]
     pub phone: Option<String>,
+    #[validate(length(max = 500))]
     pub website: Option<String>,
+    #[validate(length(max = 1000))]
     pub description: Option<String>,
     pub hours: Option<BusinessHours>,
     pub lat: Option<f64>,
@@ -145,6 +154,8 @@ pub struct BusinessSearchQuery {
     pub radius: Option<f64>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
+    pub cursor: Option<String>,
+    pub include_pagination: Option<bool>,
     pub verified_only: Option<bool>,
     pub open_now: Option<bool>,
     pub sort: Option<String>,

--- a/backend/src/models/claim.rs
+++ b/backend/src/models/claim.rs
@@ -21,7 +21,7 @@ pub enum ClaimStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BusinessClaim {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub business_id: String,
     pub user_id: String,

--- a/backend/src/models/deal.rs
+++ b/backend/src/models/deal.rs
@@ -4,7 +4,7 @@ use validator::Validate;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Deal {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub business_id: String,
     pub title: String,
@@ -34,10 +34,13 @@ pub struct DealCreate {
     pub valid_until: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 pub struct DealUpdate {
+    #[validate(length(min = 1, max = 200))]
     pub title: Option<String>,
+    #[validate(length(max = 1000))]
     pub description: Option<String>,
+    #[validate(range(min = 0.0, max = 100.0))]
     pub discount_percent: Option<f64>,
     pub original_price: Option<f64>,
     pub deal_price: Option<f64>,

--- a/backend/src/models/review.rs
+++ b/backend/src/models/review.rs
@@ -4,7 +4,7 @@ use validator::Validate;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Review {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub business_id: String,
     pub user_id: String,

--- a/backend/src/models/saved.rs
+++ b/backend/src/models/saved.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedRecord {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub user_id: String,
     pub business_id: String,

--- a/backend/src/models/subscription.rs
+++ b/backend/src/models/subscription.rs
@@ -42,19 +42,11 @@ impl SubscriptionTier {
     pub fn analytics_access(&self) -> bool {
         matches!(self, SubscriptionTier::Pro | SubscriptionTier::Premium)
     }
-
-    pub fn visibility_boost(&self) -> bool {
-        matches!(self, SubscriptionTier::Pro | SubscriptionTier::Premium)
-    }
-
-    pub fn featured_placement(&self) -> bool {
-        matches!(self, SubscriptionTier::Premium)
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Subscription {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub user_id: String,
     pub business_id: Option<String>,
@@ -89,8 +81,6 @@ pub struct TierInfo {
     pub price_usd: f64,
     pub max_deals: Option<u32>,
     pub analytics: bool,
-    pub visibility_boost: bool,
-    pub featured: bool,
 }
 
 pub fn all_tier_infos() -> Vec<TierInfo> {
@@ -101,8 +91,6 @@ pub fn all_tier_infos() -> Vec<TierInfo> {
             price_usd: 0.0,
             max_deals: Some(1),
             analytics: false,
-            visibility_boost: false,
-            featured: false,
         },
         TierInfo {
             tier: "STARTER".into(),
@@ -110,8 +98,6 @@ pub fn all_tier_infos() -> Vec<TierInfo> {
             price_usd: 9.99,
             max_deals: Some(5),
             analytics: false,
-            visibility_boost: false,
-            featured: false,
         },
         TierInfo {
             tier: "PRO".into(),
@@ -119,8 +105,6 @@ pub fn all_tier_infos() -> Vec<TierInfo> {
             price_usd: 29.99,
             max_deals: Some(20),
             analytics: true,
-            visibility_boost: true,
-            featured: false,
         },
         TierInfo {
             tier: "PREMIUM".into(),
@@ -128,8 +112,6 @@ pub fn all_tier_infos() -> Vec<TierInfo> {
             price_usd: 79.99,
             max_deals: None,
             analytics: true,
-            visibility_boost: true,
-            featured: true,
         },
     ]
 }

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -29,6 +29,9 @@ pub enum DiscoveryMode {
     #[default]
     Neighborhood,
     Citywide,
+    NewPlaces,
+    Trending,
+    Trusted,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -43,7 +46,7 @@ pub struct UserPreferences {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
+    #[serde(alias = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub email: String,
     pub full_name: Option<String>,

--- a/backend/src/routes/activity.rs
+++ b/backend/src/routes/activity.rs
@@ -2,8 +2,9 @@ use crate::{
     errors::{AppError, Result},
     middleware::auth::AuthUser,
     routes::support::{
-        business_lat_lng, eq, geo_rpc_unavailable, limit, normalize_id_alias, offset, order,
-        select_all, unwrap_rpc_items, value_i64, value_str,
+        business_lat_lng, eq, geo_rpc_unavailable, gte, limit, normalize_id_alias, offset, order,
+        pagination_headers, pagination_meta, pagination_window, q, select_all, unwrap_rpc_items,
+        value_i64, value_str,
     },
     security,
     state::AppState,
@@ -15,10 +16,10 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -41,8 +42,10 @@ pub fn router() -> Router<Arc<AppState>> {
 struct FeedParams {
     limit: Option<i64>,
     offset: Option<i64>,
+    cursor: Option<String>,
     page: Option<i64>,
     page_size: Option<i64>,
+    include_pagination: Option<bool>,
     business_id: Option<String>,
     lat: Option<f64>,
     lng: Option<f64>,
@@ -53,16 +56,23 @@ async fn get_feed(
     State(state): State<Arc<AppState>>,
     Query(params): Query<FeedParams>,
 ) -> Result<impl IntoResponse> {
-    let page_size = params.page_size.or(params.limit).unwrap_or(20).clamp(1, 50);
-    let offset_value = params
+    let requested_limit = params.page_size.or(params.limit).unwrap_or(20).clamp(1, 50);
+    let page_offset = params
         .offset
-        .unwrap_or_else(|| (params.page.unwrap_or(1).max(1) - 1) * page_size);
+        .or_else(|| params.page.map(|page| (page.max(1) - 1) * requested_limit));
+    let window = pagination_window(
+        Some(requested_limit),
+        page_offset,
+        params.cursor.as_deref(),
+        20,
+        50,
+    )?;
 
     let mut query = vec![
         select_all(),
         order("created_at.desc"),
-        limit(page_size + 1),
-        offset(offset_value),
+        limit(window.limit + 1),
+        offset(window.offset),
     ];
     if let Some(business_id) = params
         .business_id
@@ -83,10 +93,17 @@ async fn get_feed(
         .into_iter()
         .map(normalize_activity_item)
         .collect::<Vec<_>>();
-    let has_more = rows.len() > page_size as usize;
-    rows.truncate(page_size as usize);
+    let meta = pagination_meta(window.limit, window.offset, rows.len());
+    rows.truncate(window.limit as usize);
 
-    Ok(Json(json!({ "items": rows, "has_more": has_more })))
+    let body = json!({
+        "items": rows,
+        "has_more": meta.has_more,
+        "next_cursor": meta.next_cursor.clone(),
+        "pagination": &meta,
+    });
+
+    Ok((pagination_headers(&meta), Json(body)))
 }
 
 async fn check_in(
@@ -97,12 +114,14 @@ async fn check_in(
     let business_id = payload["business_id"]
         .as_str()
         .ok_or_else(|| AppError::BadRequest("business_id required".into()))?;
+    let business_id = security::validate_uuid_id(business_id, "business ID")?;
 
     let coordinates = checkin_coordinates(&payload)?;
     let lat = coordinates.map(|(lat, _)| lat);
     let lng = coordinates.map(|(_, lng)| lng);
 
-    let business = find_business(&state, business_id).await?;
+    let business = find_business(&state, &business_id).await?;
+    ensure_recent_checkin_allowed(&state, &auth_user.id, &business_id).await?;
     let distance = if let (Some((user_lat, user_lng)), Some((biz_lat, biz_lng))) =
         (coordinates, business_lat_lng(&business))
     {
@@ -126,7 +145,7 @@ async fn check_in(
         .insert_json(
             "checkins",
             json!({
-                "business_id": business_id,
+                "business_id": &business_id,
                 "user_id": auth_user.id,
                 "status": status,
                 "latitude": lat,
@@ -155,7 +174,7 @@ async fn check_in(
             "activity_type": "checkin",
             "user_id": auth_user.id,
             "user_name": auth_user.display_name(),
-            "business_id": business_id,
+            "business_id": &business_id,
             "business_name": value_str(&business, "name"),
             "business_category": value_str(&business, "category"),
             "title": title,
@@ -199,6 +218,9 @@ async fn toggle_like(
     auth_user: AuthUser,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse> {
+    let id = security::validate_uuid_id(&id, "activity ID")?;
+    ensure_activity_action_allowed(&state, &auth_user.id, "like", 40, Duration::minutes(10))
+        .await?;
     let existing = find_activity(&state, &id).await?;
     let mut liked_by = existing["liked_by"]
         .as_array()
@@ -236,9 +258,17 @@ async fn toggle_like(
 async fn get_comments(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
+    Query(params): Query<CommentParams>,
 ) -> Result<impl IntoResponse> {
     let id = security::validate_uuid_id(&id, "activity ID")?;
-    let comments = state
+    let window = pagination_window(
+        params.limit,
+        params.offset,
+        params.cursor.as_deref(),
+        50,
+        100,
+    )?;
+    let mut comments = state
         .db
         .supabase
         .select_json(
@@ -247,14 +277,29 @@ async fn get_comments(
                 select_all(),
                 eq("activity_id", &id),
                 order("created_at.asc"),
+                limit(window.limit + 1),
+                offset(window.offset),
             ],
         )
         .await?
         .into_iter()
         .map(normalize_comment)
         .collect::<Vec<_>>();
+    let meta = pagination_meta(window.limit, window.offset, comments.len());
+    comments.truncate(window.limit as usize);
 
-    Ok(Json(comments))
+    let body = if params.include_pagination.unwrap_or(false) {
+        json!({
+            "items": comments,
+            "pagination": &meta,
+            "has_more": meta.has_more,
+            "next_cursor": meta.next_cursor.clone(),
+        })
+    } else {
+        json!(comments)
+    };
+
+    Ok((pagination_headers(&meta), Json(body)))
 }
 
 async fn add_comment(
@@ -271,6 +316,9 @@ async fn add_comment(
     if content.is_empty() {
         return Err(AppError::BadRequest("content required".into()));
     }
+    ensure_activity_action_allowed(&state, &auth_user.id, "comment", 20, Duration::minutes(10))
+        .await?;
+    ensure_recent_comment_allowed(&state, &id, &auth_user.id).await?;
 
     let now = Utc::now().to_rfc3339();
     let comment = state
@@ -324,6 +372,8 @@ async fn create_feed_post(
     if content.is_empty() {
         return Err(AppError::BadRequest("content required".into()));
     }
+    ensure_activity_action_allowed(&state, &auth_user.id, "post", 12, Duration::minutes(10))
+        .await?;
 
     let business = if let Some(business_id) = payload["business_id"].as_str() {
         Some(find_business(&state, business_id).await?)
@@ -386,21 +436,21 @@ async fn get_activity_pulse(
         )
         .await?;
 
+    let business_ids = rows
+        .iter()
+        .filter_map(|row| {
+            let id = value_str(row, "business_id");
+            (!id.is_empty()).then(|| id.to_string())
+        })
+        .collect::<Vec<_>>();
+    let businesses = fetch_businesses_by_ids(&state, &business_ids).await?;
+
     let mut items = Vec::new();
     for row in rows {
         let business_id = value_str(&row, "business_id").to_string();
-        let business = if business_id.is_empty() {
-            None
-        } else {
-            match find_business(&state, &business_id).await {
-                Ok(business) => Some(business),
-                Err(AppError::NotFound(_)) => None,
-                Err(err) => return Err(err),
-            }
-        };
+        let business = businesses.get(&business_id);
 
-        if let (Some(lat), Some(lng), Some(business)) = (params.lat, params.lng, business.as_ref())
-        {
+        if let (Some(lat), Some(lng), Some(business)) = (params.lat, params.lng, business) {
             let Some((biz_lat, biz_lng)) = business_lat_lng(business) else {
                 continue;
             };
@@ -419,9 +469,9 @@ async fn get_activity_pulse(
             "timestamp": value_str(&row, "created_at"),
             "business": {
                 "business_id": value_str(&row, "business_id"),
-                "name": business.as_ref().map(|item| value_str(item, "name")).unwrap_or_else(|| value_str(&row, "business_name")),
-                "category": business.as_ref().map(|item| value_str(item, "category")).unwrap_or_else(|| value_str(&row, "business_category")),
-                "image_url": business.as_ref().and_then(|item| item.get("primary_image_url").or_else(|| item.get("image_url"))).cloned().unwrap_or(Value::Null),
+                "name": business.map(|item| value_str(item, "name")).unwrap_or_else(|| value_str(&row, "business_name")),
+                "category": business.map(|item| value_str(item, "category")).unwrap_or_else(|| value_str(&row, "business_category")),
+                "image_url": business.and_then(|item| item.get("primary_image_url").or_else(|| item.get("image_url"))).cloned().unwrap_or(Value::Null),
             }
         }));
 
@@ -461,46 +511,79 @@ async fn get_business_activity(
     Path(business_id): Path<String>,
 ) -> Result<impl IntoResponse> {
     let business_id = security::validate_uuid_id(&business_id, "business ID")?;
-    let checkins = state
+    let now = Utc::now();
+    let today_start = now
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .expect("midnight is a valid time")
+        .and_utc()
+        .to_rfc3339();
+    let week_start = (now - Duration::days(7)).to_rfc3339();
+
+    let checkins_today = state
         .db
         .supabase
-        .select_json(
+        .count(
+            "checkins",
+            &[
+                eq("business_id", &business_id),
+                gte("created_at", &today_start),
+            ],
+        )
+        .await? as i64;
+    let checkins_this_week = state
+        .db
+        .supabase
+        .count(
+            "checkins",
+            &[
+                eq("business_id", &business_id),
+                gte("created_at", &week_start),
+            ],
+        )
+        .await? as i64;
+    let last_checkin = state
+        .db
+        .supabase
+        .select_one_json(
             "checkins",
             &[
                 select_all(),
                 eq("business_id", &business_id),
                 order("created_at.desc"),
+                limit(1),
             ],
         )
         .await?;
-    let feed = state
+    let recent_activity_count = state
         .db
         .supabase
-        .select_json(
+        .count(
             "activity_feed",
             &[
-                select_all(),
                 eq("business_id", &business_id),
-                order("created_at.desc"),
+                gte("created_at", &week_start),
             ],
         )
-        .await?;
-
-    let today_prefix = Utc::now().format("%Y-%m-%d").to_string();
-    let checkins_today = checkins
-        .iter()
-        .filter(|row| value_str(row, "created_at").starts_with(&today_prefix))
-        .count() as i64;
+        .await? as i64;
 
     Ok(Json(json!({
         "business_id": business_id,
         "is_active_today": checkins_today > 0,
         "checkins_today": checkins_today,
-        "checkins_this_week": checkins.len(),
-        "last_checkin_at": checkins.first().and_then(|row| row.get("created_at")).cloned(),
-        "recent_activity_count": feed.len(),
-        "trending_score": (checkins_today as f64 * 2.0) + feed.len() as f64,
+        "checkins_this_week": checkins_this_week,
+        "last_checkin_at": last_checkin.and_then(|row| row.get("created_at").cloned()),
+        "recent_activity_count": recent_activity_count,
+        "trending_score": (checkins_today as f64 * 2.0) + recent_activity_count as f64,
     })))
+}
+
+#[derive(Deserialize)]
+struct CommentParams {
+    limit: Option<i64>,
+    offset: Option<i64>,
+    cursor: Option<String>,
+    include_pagination: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -566,10 +649,19 @@ async fn list_owner_events(
         events.retain(|event| value_str(event, "end_time") >= now.as_str());
     }
 
+    let business_ids = events
+        .iter()
+        .filter_map(|event| {
+            let id = value_str(event, "business_id");
+            (!id.is_empty()).then(|| id.to_string())
+        })
+        .collect::<Vec<_>>();
+    let businesses = fetch_businesses_by_ids(&state, &business_ids).await?;
+
     for event in &mut events {
-        if let Ok(business) = find_business(&state, value_str(event, "business_id")).await {
+        if let Some(business) = businesses.get(value_str(event, "business_id")) {
             if let (Some(lat), Some(lng)) = (params.lat, params.lng) {
-                let Some((biz_lat, biz_lng)) = business_lat_lng(&business) else {
+                let Some((biz_lat, biz_lng)) = business_lat_lng(business) else {
                     event["__exclude"] = json!(true);
                     continue;
                 };
@@ -581,8 +673,8 @@ async fn list_owner_events(
                     continue;
                 }
             }
-            event["business_name"] = json!(value_str(&business, "name"));
-            event["business_category"] = json!(value_str(&business, "category"));
+            event["business_name"] = json!(value_str(business, "name"));
+            event["business_category"] = json!(value_str(business, "category"));
             event["business_image_url"] = business
                 .get("primary_image_url")
                 .or_else(|| business.get("image_url"))
@@ -795,6 +887,43 @@ async fn find_business(state: &AppState, id: &str) -> Result<Value> {
         .ok_or_else(|| AppError::NotFound("Business not found".into()))
 }
 
+async fn fetch_businesses_by_ids(
+    state: &AppState,
+    business_ids: &[String],
+) -> Result<HashMap<String, Value>> {
+    if business_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut unique_ids = Vec::new();
+    for id in business_ids {
+        let id = security::validate_uuid_id(id, "business ID")?;
+        if !unique_ids.contains(&id) {
+            unique_ids.push(id);
+        }
+    }
+
+    let rows = state
+        .db
+        .supabase
+        .select_json(
+            "businesses",
+            &[
+                select_all(),
+                q("id", format!("in.({})", unique_ids.join(","))),
+            ],
+        )
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let id = value_str(&row, "id").to_string();
+            (!id.is_empty()).then_some((id, row))
+        })
+        .collect())
+}
+
 async fn find_activity(state: &AppState, id: &str) -> Result<Value> {
     let id = security::validate_uuid_id(id, "activity ID")?;
     state
@@ -807,6 +936,82 @@ async fn find_activity(state: &AppState, id: &str) -> Result<Value> {
 
 async fn insert_activity(state: &AppState, body: Value) -> Result<Value> {
     Ok(state.db.supabase.insert_json("activity_feed", body).await?)
+}
+
+async fn ensure_recent_checkin_allowed(
+    state: &AppState,
+    user_id: &str,
+    business_id: &str,
+) -> Result<()> {
+    let since = (Utc::now() - Duration::minutes(30)).to_rfc3339();
+    let recent = state
+        .db
+        .supabase
+        .count(
+            "checkins",
+            &[
+                eq("user_id", user_id),
+                eq("business_id", business_id),
+                gte("created_at", since),
+            ],
+        )
+        .await?;
+    if recent > 0 {
+        return Err(AppError::Conflict(
+            "You recently checked in at this business".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn ensure_recent_comment_allowed(
+    state: &AppState,
+    activity_id: &str,
+    user_id: &str,
+) -> Result<()> {
+    let since = (Utc::now() - Duration::minutes(1)).to_rfc3339();
+    let recent = state
+        .db
+        .supabase
+        .count(
+            "activity_comments",
+            &[
+                eq("activity_id", activity_id),
+                eq("user_id", user_id),
+                gte("created_at", since),
+            ],
+        )
+        .await?;
+    if recent > 0 {
+        return Err(AppError::Conflict(
+            "Please wait before commenting again on this activity".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn ensure_activity_action_allowed(
+    state: &AppState,
+    user_id: &str,
+    action: &str,
+    limit: u32,
+    window: Duration,
+) -> Result<()> {
+    let key = format!("activity:{}:{}", action, user_id);
+    if state
+        .rate_limiter
+        .check(
+            &key,
+            limit,
+            window
+                .to_std()
+                .unwrap_or(std::time::Duration::from_secs(60)),
+        )
+        .await
+    {
+        return Ok(());
+    }
+    Err(AppError::RateLimited)
 }
 
 fn ensure_business_owner(row: &Value, auth_user: &AuthUser) -> Result<()> {

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -45,6 +45,7 @@ async fn register(
             .ok_or_else(|| AppError::BadRequest("reCAPTCHA token required".into()))?;
 
         recaptcha::verify_recaptcha_token(
+            &state.recaptcha_http,
             &state.config,
             token,
             &state.config.recaptcha_signup_action,
@@ -68,8 +69,26 @@ async fn register(
 
     // Force metadata into Supabase Auth before login so the newly minted JWT
     // carries the selected registration role immediately.
-    let user =
-        update_registration_metadata(&state, created_user, role, full_name.as_deref()).await?;
+    let user = match update_registration_metadata(
+        &state,
+        created_user.clone(),
+        role,
+        full_name.as_deref(),
+    )
+    .await
+    {
+        Ok(user) => user,
+        Err(err) => {
+            if let Err(delete_err) = state.db.supabase.auth_delete_user(&created_user.id).await {
+                tracing::warn!(
+                    error = %delete_err,
+                    user_id = %created_user.id,
+                    "Failed to roll back Supabase user after registration metadata failure"
+                );
+            }
+            return Err(err);
+        }
+    };
 
     let session = state
         .db
@@ -108,7 +127,13 @@ async fn login(
     ))
 }
 
-async fn logout(State(state): State<Arc<AppState>>) -> Response {
+async fn logout(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    if let Some(access_token) = auth::access_token_from_headers(&headers) {
+        if let Err(err) = state.db.supabase.auth_logout(&access_token).await {
+            tracing::warn!(error = %err, "Supabase logout token revocation failed");
+        }
+    }
+
     (
         clear_session_headers(&state.config),
         Json(json!({ "message": "Logged out successfully" })),

--- a/backend/src/routes/businesses.rs
+++ b/backend/src/routes/businesses.rs
@@ -4,7 +4,8 @@ use crate::{
     models::business::{BusinessCreate, BusinessSearchQuery, BusinessUpdate},
     routes::support::{
         business_lat_lng, eq, geo_rpc_unavailable, ilike_or_filter, is_true, limit,
-        normalize_business, offset, order, select_all, unwrap_rpc_items, value_str, QueryParams,
+        normalize_business, offset, order, pagination_headers, pagination_meta, pagination_window,
+        select_all, unwrap_rpc_items, value_str, QueryParams,
     },
     security,
     state::AppState,
@@ -21,6 +22,8 @@ use chrono::Utc;
 use serde_json::{json, Map, Value};
 use std::sync::Arc;
 use validator::Validate;
+
+const MAX_GOOGLE_PHOTO_BYTES: u64 = 8 * 1024 * 1024;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
@@ -44,8 +47,29 @@ async fn list_businesses(
     State(state): State<Arc<AppState>>,
     Query(params): Query<BusinessSearchQuery>,
 ) -> Result<impl IntoResponse> {
-    let rows = query_businesses(&state, &params, params.limit.unwrap_or(100).clamp(1, 200)).await?;
-    Ok(Json(rows))
+    let window = pagination_window(
+        params.limit,
+        params.offset,
+        params.cursor.as_deref(),
+        100,
+        200,
+    )?;
+    let mut rows = query_businesses(&state, &params, window.limit + 1, window.offset).await?;
+    let meta = pagination_meta(window.limit, window.offset, rows.len());
+    rows.truncate(window.limit as usize);
+
+    let body = if params.include_pagination.unwrap_or(false) {
+        json!({
+            "items": rows,
+            "pagination": &meta,
+            "has_more": meta.has_more,
+            "next_cursor": meta.next_cursor.clone(),
+        })
+    } else {
+        json!(rows)
+    };
+
+    Ok((pagination_headers(&meta), Json(body)))
 }
 
 async fn nearby_businesses(
@@ -53,8 +77,29 @@ async fn nearby_businesses(
     Query(mut params): Query<BusinessSearchQuery>,
 ) -> Result<impl IntoResponse> {
     params.sort = Some("distance".into());
-    let rows = query_businesses(&state, &params, params.limit.unwrap_or(50).clamp(1, 100)).await?;
-    Ok(Json(rows))
+    let window = pagination_window(
+        params.limit,
+        params.offset,
+        params.cursor.as_deref(),
+        50,
+        100,
+    )?;
+    let mut rows = query_businesses(&state, &params, window.limit + 1, window.offset).await?;
+    let meta = pagination_meta(window.limit, window.offset, rows.len());
+    rows.truncate(window.limit as usize);
+
+    let body = if params.include_pagination.unwrap_or(false) {
+        json!({
+            "items": rows,
+            "pagination": &meta,
+            "has_more": meta.has_more,
+            "next_cursor": meta.next_cursor.clone(),
+        })
+    } else {
+        json!(rows)
+    };
+
+    Ok((pagination_headers(&meta), Json(body)))
 }
 
 async fn get_business(
@@ -90,7 +135,7 @@ async fn create_business(
         json!(security::sanitize_text(&payload.address, 300)),
     );
     body.insert("is_verified".into(), json!(false));
-    body.insert("is_claimed".into(), json!(false));
+    body.insert("is_claimed".into(), json!(true));
     body.insert("owner_id".into(), json!(auth_user.id));
     body.insert("review_count".into(), json!(0));
     body.insert("photos".into(), json!([]));
@@ -135,6 +180,9 @@ async fn update_business(
     Json(payload): Json<BusinessUpdate>,
 ) -> Result<impl IntoResponse> {
     let id = security::validate_uuid_id(&id, "business ID")?;
+    payload
+        .validate()
+        .map_err(|e| AppError::BadRequest(e.to_string()))?;
     let existing = find_business(&state, &id).await?;
     ensure_business_owner(&existing, &auth_user)?;
 
@@ -270,10 +318,13 @@ async fn get_google_place_photo(
         return Err(AppError::BadRequest("Google API not configured".into()));
     }
 
-    let details =
-        crate::services::google_places::get_place_details(&state.config.google_api_key, &place_id)
-            .await
-            .map_err(|_| AppError::BadRequest("Google place details are unavailable".into()))?;
+    let details = crate::services::google_places::get_place_details(
+        &state.google_http,
+        &state.config.google_api_key,
+        &place_id,
+    )
+    .await
+    .map_err(|_| AppError::BadRequest("Google place details are unavailable".into()))?;
     let photo_ref = details["photos"]
         .as_array()
         .and_then(|photos| photos.first())
@@ -307,14 +358,17 @@ async fn proxy_google_photo(
     )
     .await;
 
-    let response = crate::services::google_places::google_http_client()
-        .map_err(|_| AppError::Internal("Google HTTP client unavailable".into()))?
+    let mut response = state
+        .google_http
         .get(&url)
         .send()
         .await
-        .map_err(|_| AppError::BadRequest("Photo is unavailable".into()))?;
+        .map_err(|_| AppError::ServiceUnavailable("Photo is unavailable".into()))?;
     if !response.status().is_success() {
-        return Err(AppError::BadRequest("Photo is unavailable".into()));
+        return Err(AppError::ServiceUnavailable("Photo is unavailable".into()));
+    }
+    if response.content_length().unwrap_or(0) > MAX_GOOGLE_PHOTO_BYTES {
+        return Err(AppError::BadRequest("Photo is too large".into()));
     }
 
     let content_type = response
@@ -322,10 +376,7 @@ async fn proxy_google_photo(
         .get(header::CONTENT_TYPE)
         .cloned()
         .unwrap_or_else(|| HeaderValue::from_static("image/jpeg"));
-    let body: Bytes = response
-        .bytes()
-        .await
-        .map_err(|_| AppError::BadRequest("Photo is unavailable".into()))?;
+    let body = read_limited_response_bytes(&mut response, MAX_GOOGLE_PHOTO_BYTES).await?;
 
     Ok((
         [
@@ -340,15 +391,34 @@ async fn proxy_google_photo(
         .into_response())
 }
 
+async fn read_limited_response_bytes(
+    response: &mut reqwest::Response,
+    max_bytes: u64,
+) -> Result<Bytes> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| AppError::ServiceUnavailable("Photo is unavailable".into()))?
+    {
+        if body.len() as u64 + chunk.len() as u64 > max_bytes {
+            return Err(AppError::BadRequest("Photo is too large".into()));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(Bytes::from(body))
+}
+
 async fn query_businesses(
     state: &AppState,
     params: &BusinessSearchQuery,
     limit_value: i64,
+    offset_value: i64,
 ) -> Result<Vec<Value>> {
     let has_coordinates = security::validate_optional_lat_lng(params.lat, params.lng)?.is_some();
 
     if has_coordinates {
-        match query_businesses_geo(state, params, limit_value).await {
+        match query_businesses_geo(state, params, limit_value, offset_value).await {
             Ok(rows) => return Ok(rows),
             Err(err) if geo_rpc_unavailable(&err.to_string()) => {
                 tracing::warn!(
@@ -367,7 +437,7 @@ async fn query_businesses(
         } else {
             limit_value
         }),
-        offset(params.offset.unwrap_or(0)),
+        offset(offset_value),
     ];
 
     if let Some(category) = params.category.as_ref().filter(|value| !value.is_empty()) {
@@ -447,6 +517,7 @@ async fn query_businesses_geo(
     state: &AppState,
     params: &BusinessSearchQuery,
     limit_value: i64,
+    offset_value: i64,
 ) -> anyhow::Result<Vec<Value>> {
     let lat = params.lat.expect("validated before geospatial query");
     let lng = params.lng.expect("validated before geospatial query");
@@ -477,7 +548,7 @@ async fn query_businesses_geo(
                 "p_lng": lng,
                 "p_radius_km": params.radius_km.or(params.radius).unwrap_or(25.0).clamp(0.1, 150.0),
                 "p_limit": (limit_value * 3).clamp(1, 600),
-                "p_offset": params.offset.unwrap_or(0).max(0),
+                "p_offset": offset_value.max(0),
                 "p_category": category,
                 "p_search": search,
                 "p_verified_only": params.verified_only.unwrap_or(false),
@@ -491,15 +562,15 @@ async fn query_businesses_geo(
         .map(normalize_business)
         .collect::<Vec<_>>();
 
-    match Some(sort) {
-        Some("distance") => businesses.sort_by(|a, b| {
+    match sort {
+        "distance" => businesses.sort_by(|a, b| {
             a["distance_km"]
                 .as_f64()
                 .unwrap_or(f64::MAX)
                 .partial_cmp(&b["distance_km"].as_f64().unwrap_or(f64::MAX))
                 .unwrap_or(std::cmp::Ordering::Equal)
         }),
-        Some("rating") => businesses.sort_by(|a, b| {
+        "rating" => businesses.sort_by(|a, b| {
             b["rating"]
                 .as_f64()
                 .unwrap_or(0.0)

--- a/backend/src/routes/claims.rs
+++ b/backend/src/routes/claims.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::{AppError, Result},
     middleware::auth::AuthUser,
-    routes::support::{eq, normalize_id_alias, order, select_all, value_str},
+    routes::support::{eq, normalize_id_alias, order, q, select_all, value_str},
     security,
     state::AppState,
 };
@@ -104,7 +104,8 @@ async fn submit_claim(
         .db
         .supabase
         .insert_json("claims", Value::Object(body))
-        .await?;
+        .await
+        .map_err(map_claim_insert_error)?;
 
     Ok((StatusCode::CREATED, Json(normalize_id_alias(created))))
 }
@@ -139,7 +140,7 @@ async fn my_claims(
         .map(normalize_id_alias)
         .collect::<Vec<_>>();
 
-    Ok(Json(json!({ "items": claims, "claims": claims })))
+    Ok(Json(json!({ "items": claims })))
 }
 
 async fn review_claim(
@@ -166,6 +167,10 @@ async fn review_claim(
     };
 
     let existing = find_claim(&state, &id).await?;
+    if value_str(&existing, "status") != "pending" {
+        return Err(AppError::Conflict("Claim has already been reviewed".into()));
+    }
+
     if normalized_status == "verified" {
         let business_id = value_str(&existing, "business_id").to_string();
         let claimant_id = value_str(&existing, "user_id").to_string();
@@ -176,12 +181,18 @@ async fn review_claim(
             .await?
             .ok_or_else(|| AppError::NotFound("Business not found".into()))?;
         ensure_business_can_be_verified_for_claim(&business, &claimant_id)?;
-        state
+        let updated_business = state
             .db
             .supabase
             .update_json(
                 "businesses",
-                &[eq("id", &business_id)],
+                &[
+                    eq("id", &business_id),
+                    q(
+                        "or",
+                        format!("(owner_id.is.null,owner_id.eq.{})", claimant_id),
+                    ),
+                ],
                 json!({
                     "is_claimed": true,
                     "owner_id": claimant_id,
@@ -189,6 +200,9 @@ async fn review_claim(
                 }),
             )
             .await?;
+        if updated_business.is_empty() {
+            return Err(AppError::Conflict("Business is already claimed".into()));
+        }
     }
 
     let now = Utc::now().to_rfc3339();
@@ -197,7 +211,7 @@ async fn review_claim(
         .supabase
         .update_json(
             "claims",
-            &[eq("id", &id)],
+            &[eq("id", &id), eq("status", "pending")],
             json!({
                 "status": normalized_status,
                 "reviewed_by": auth_user.id,
@@ -211,7 +225,7 @@ async fn review_claim(
     let claim = updated
         .into_iter()
         .next()
-        .ok_or_else(|| AppError::NotFound("Claim not found".into()))?;
+        .ok_or_else(|| AppError::Conflict("Claim has already been reviewed".into()))?;
     Ok(Json(normalize_id_alias(claim)))
 }
 
@@ -252,6 +266,15 @@ fn ensure_business_can_be_verified_for_claim(business: &Value, claimant_id: &str
 fn insert_optional(body: &mut Map<String, Value>, key: &str, value: Option<&str>, max: usize) {
     if let Some(value) = value.and_then(|raw| security::sanitize_optional_text(Some(raw), max)) {
         body.insert(key.into(), json!(value));
+    }
+}
+
+fn map_claim_insert_error(err: anyhow::Error) -> AppError {
+    let message = err.to_string().to_ascii_lowercase();
+    if message.contains("duplicate") || message.contains("unique") {
+        AppError::Conflict("Claim already pending".into())
+    } else {
+        err.into()
     }
 }
 

--- a/backend/src/routes/deals.rs
+++ b/backend/src/routes/deals.rs
@@ -2,8 +2,8 @@ use crate::{
     errors::{AppError, Result},
     middleware::auth::AuthUser,
     routes::support::{
-        eq, is_true, limit, normalize_deal, order, q, select_all, unwrap_rpc_items, value_str,
-        QueryParams,
+        eq, is_true, limit, normalize_deal, offset, order, q, select_all, unwrap_rpc_items,
+        value_str, QueryParams,
     },
     security,
     state::AppState,
@@ -46,6 +46,7 @@ async fn list_deals(
         is_true("is_active"),
         order("created_at.desc"),
         limit(params.limit.unwrap_or(50).clamp(1, 100)),
+        offset(params.offset.unwrap_or(0).max(0)),
     ];
     let deals = state
         .db
@@ -71,6 +72,7 @@ async fn list_business_deals(
         is_true("is_active"),
         order("created_at.desc"),
         limit(params.limit.unwrap_or(20).clamp(1, 100)),
+        offset(params.offset.unwrap_or(0).max(0)),
     ];
     let deals = state
         .db
@@ -117,13 +119,15 @@ async fn create_deal(
     let business_id = security::validate_uuid_id(&payload.business_id, "business ID")?;
     let business = find_business(&state, &business_id).await?;
     ensure_business_owner(&business, &auth_user)?;
+    ensure_deal_limit_available(&state, &business_id).await?;
 
     let now = Utc::now();
-    let discount_value = payload
-        .discount_value
-        .or(payload.discount_percent)
-        .unwrap_or(0.0)
-        .max(0.0);
+    let title = validate_deal_title(&payload.title)?;
+    let discount_type = validate_discount_type(payload.discount_type.as_deref())?;
+    let discount_value = validate_discount_value(
+        discount_type,
+        payload.discount_value.or(payload.discount_percent),
+    )?;
     let valid_until = match payload.valid_until {
         Some(value) => validate_rfc3339("valid_until", &value)?,
         None => (now + Duration::days(30)).to_rfc3339(),
@@ -131,10 +135,7 @@ async fn create_deal(
 
     let mut body = Map::new();
     body.insert("business_id".into(), json!(&business_id));
-    body.insert(
-        "title".into(),
-        json!(security::sanitize_text(&payload.title, 200)),
-    );
+    body.insert("title".into(), json!(title));
     body.insert(
         "description".into(),
         json!(
@@ -142,10 +143,7 @@ async fn create_deal(
                 .unwrap_or_default()
         ),
     );
-    body.insert(
-        "discount_type".into(),
-        json!(validate_discount_type(payload.discount_type.as_deref())?),
-    );
+    body.insert("discount_type".into(), json!(discount_type));
     body.insert("discount_value".into(), json!(discount_value));
     body.insert("discount_percent".into(), json!(discount_value));
     body.insert("valid_until".into(), json!(valid_until));
@@ -186,6 +184,8 @@ struct DealUpdate {
     discount_value: Option<f64>,
     code: Option<String>,
     valid_until: Option<String>,
+    original_price: Option<f64>,
+    deal_price: Option<f64>,
     is_active: Option<bool>,
 }
 
@@ -201,13 +201,19 @@ async fn update_deal(
 
     let mut body = Map::new();
     body.insert("updated_at".into(), json!(Utc::now().to_rfc3339()));
-    insert_optional(&mut body, "title", payload.title.as_deref(), 200);
+    if let Some(title) = payload.title.as_deref() {
+        body.insert("title".into(), json!(validate_deal_title(title)?));
+    }
     insert_optional(
         &mut body,
         "description",
         payload.description.as_deref(),
         1000,
     );
+    let effective_discount_type = payload.discount_type.as_deref().or_else(|| {
+        let existing_type = value_str(&existing, "discount_type");
+        (!existing_type.is_empty()).then_some(existing_type)
+    });
     if payload.discount_type.is_some() {
         body.insert(
             "discount_type".into(),
@@ -221,12 +227,26 @@ async fn update_deal(
             json!(validate_rfc3339("valid_until", &valid_until)?),
         );
     }
-    if let Some(value) = payload.discount_value.or(payload.discount_percent) {
-        if !value.is_finite() || value < 0.0 {
-            return Err(AppError::BadRequest("Invalid discount value".into()));
-        }
+    if payload.discount_value.is_some() || payload.discount_percent.is_some() {
+        let discount_type = validate_discount_type(effective_discount_type)?;
+        let value = validate_discount_value(
+            discount_type,
+            payload.discount_value.or(payload.discount_percent),
+        )?;
         body.insert("discount_value".into(), json!(value));
         body.insert("discount_percent".into(), json!(value));
+    }
+    if let Some(value) = payload.original_price {
+        body.insert(
+            "original_price".into(),
+            json!(validate_price("original_price", value)?),
+        );
+    }
+    if let Some(value) = payload.deal_price {
+        body.insert(
+            "deal_price".into(),
+            json!(validate_price("deal_price", value)?),
+        );
     }
     if let Some(active) = payload.is_active {
         body.insert("is_active".into(), json!(active));
@@ -377,6 +397,75 @@ fn ensure_business_owner(row: &Value, auth_user: &AuthUser) -> Result<()> {
     Ok(())
 }
 
+async fn ensure_deal_limit_available(state: &AppState, business_id: &str) -> Result<()> {
+    let Some(max_deals) = active_deal_limit_for_business(state, business_id).await? else {
+        return Ok(());
+    };
+
+    let active_count = state
+        .db
+        .supabase
+        .count(
+            "deals",
+            &[
+                eq("business_id", business_id),
+                is_true("is_active"),
+                current_deals_filter(Utc::now()),
+            ],
+        )
+        .await?;
+
+    if active_count >= max_deals as usize {
+        return Err(AppError::BadRequest(
+            "Active deal limit reached for the current plan".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn active_deal_limit_for_business(
+    state: &AppState,
+    business_id: &str,
+) -> Result<Option<u32>> {
+    let rows = state
+        .db
+        .supabase
+        .select_json(
+            "subscriptions",
+            &[
+                q("select", "tier"),
+                eq("business_id", business_id),
+                eq("status", "active"),
+            ],
+        )
+        .await?;
+    let tier = rows
+        .iter()
+        .filter_map(|row| row.get("tier").and_then(Value::as_str))
+        .max_by_key(|tier| subscription_tier_rank(tier))
+        .unwrap_or("free");
+
+    Ok(max_deals_for_tier(tier))
+}
+
+fn max_deals_for_tier(tier: &str) -> Option<u32> {
+    match tier.to_ascii_lowercase().as_str() {
+        "premium" => None,
+        "pro" => Some(20),
+        "starter" => Some(5),
+        _ => Some(1),
+    }
+}
+
+fn subscription_tier_rank(tier: &str) -> u8 {
+    match tier.to_ascii_lowercase().as_str() {
+        "premium" => 3,
+        "pro" => 2,
+        "starter" => 1,
+        _ => 0,
+    }
+}
+
 fn insert_optional(body: &mut Map<String, Value>, key: &str, value: Option<&str>, max: usize) {
     if let Some(value) = value.and_then(|raw| security::sanitize_optional_text(Some(raw), max)) {
         body.insert(key.into(), json!(value));
@@ -394,6 +483,34 @@ fn validate_discount_type(value: Option<&str>) -> Result<&'static str> {
         "fixed" | "fixed_amount" | "amount" => Ok("fixed"),
         _ => Err(AppError::BadRequest("Invalid discount type".into())),
     }
+}
+
+fn validate_deal_title(value: &str) -> Result<String> {
+    let title = security::sanitize_text(value, 200);
+    if title.is_empty() {
+        return Err(AppError::BadRequest("Deal title required".into()));
+    }
+    Ok(title)
+}
+
+fn validate_discount_value(discount_type: &str, value: Option<f64>) -> Result<f64> {
+    let value = value.unwrap_or(0.0);
+    if !value.is_finite() || value < 0.0 {
+        return Err(AppError::BadRequest("Invalid discount value".into()));
+    }
+    if discount_type == "percentage" && value > 100.0 {
+        return Err(AppError::BadRequest(
+            "Percentage discount cannot exceed 100".into(),
+        ));
+    }
+    Ok(value)
+}
+
+fn validate_price(label: &str, value: f64) -> Result<f64> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(AppError::BadRequest(format!("Invalid {}", label)));
+    }
+    Ok(value)
 }
 
 fn deal_is_current(row: &Value) -> bool {

--- a/backend/src/routes/discovery.rs
+++ b/backend/src/routes/discovery.rs
@@ -121,6 +121,8 @@ async fn explore_lanes(
         lane_params.lng = Some(lng);
         lane_params.limit = Some(10);
         lane_params.category = category.map(str::to_string);
+        lane_params.q = None;
+        lane_params.search = None;
         lane_params.sort = Some(if id == "trusted" {
             "rating".into()
         } else {
@@ -143,11 +145,12 @@ async fn explore_lanes(
 
 async fn decide_from_params(state: &AppState, mut params: DiscoverParams) -> Result<Value> {
     let intent = params.intent.clone().unwrap_or_else(|| "EXPLORE".into());
+    let requested_limit = params.limit.unwrap_or(3).clamp(1, 10);
     if params.category.is_none() {
         params.category = category_for_intent(&intent).map(str::to_string);
     }
     params.sort = Some("canonical".into());
-    params.limit = Some(params.limit.unwrap_or(3).clamp(1, 10) * 5);
+    params.limit = Some(requested_limit * 5);
 
     let constraints = params
         .constraints
@@ -160,7 +163,7 @@ async fn decide_from_params(state: &AppState, mut params: DiscoverParams) -> Res
 
     let mut rows = discover_rows(state, &params).await?;
     rows.retain(|row| passes_decide_constraints(row, &constraints));
-    rows.truncate(params.limit.unwrap_or(15).min(5) as usize);
+    rows.truncate(requested_limit as usize);
 
     Ok(json!({
         "items": rows,
@@ -335,15 +338,15 @@ async fn discover_rows_geo(
         })
         .collect::<Vec<_>>();
 
-    match Some(sort) {
-        Some("distance") => results.sort_by(|a, b| {
+    match sort {
+        "distance" => results.sort_by(|a, b| {
             a["distance_km"]
                 .as_f64()
                 .unwrap_or(f64::MAX)
                 .partial_cmp(&b["distance_km"].as_f64().unwrap_or(f64::MAX))
                 .unwrap_or(std::cmp::Ordering::Equal)
         }),
-        Some("rating") | Some("most_reviewed") => results.sort_by(|a, b| {
+        "rating" | "most_reviewed" => results.sort_by(|a, b| {
             let left = (
                 b["rating"].as_f64().unwrap_or(0.0),
                 b["review_count"].as_i64().unwrap_or(0),
@@ -355,7 +358,7 @@ async fn discover_rows_geo(
             left.partial_cmp(&right)
                 .unwrap_or(std::cmp::Ordering::Equal)
         }),
-        Some("newest") => results.sort_by(|a, b| {
+        "newest" => results.sort_by(|a, b| {
             b["created_at"]
                 .as_str()
                 .unwrap_or("")
@@ -387,7 +390,7 @@ fn passes_decide_constraints(row: &Value, constraints: &[String]) -> bool {
     constraints
         .iter()
         .all(|constraint| match constraint.as_str() {
-            "OPEN_NOW" => row["open_now"].as_bool().unwrap_or(true),
+            "OPEN_NOW" => row["open_now"].as_bool().unwrap_or(false),
             "CHEAP" => row["price_level"].as_i64().unwrap_or(2) <= 1,
             "MOST_TRUSTED" => row["rating"].as_f64().unwrap_or(0.0) >= 4.0,
             "HIDDEN_GEM" => row["review_count"].as_i64().unwrap_or(0) < 50,

--- a/backend/src/routes/location.rs
+++ b/backend/src/routes/location.rs
@@ -41,12 +41,13 @@ async fn reverse_geocode(
     }
 
     let resp = crate::services::google_places::reverse_geocode(
+        &state.google_http,
         &state.config.google_api_key,
         params.lat,
         params.lng,
     )
     .await
-    .map_err(|_| AppError::BadRequest("Reverse geocoding is unavailable".into()))?;
+    .map_err(|_| AppError::ServiceUnavailable("Reverse geocoding is unavailable".into()))?;
 
     let results = resp["results"].as_array().cloned().unwrap_or_default();
     if results.is_empty() {

--- a/backend/src/routes/reviews.rs
+++ b/backend/src/routes/reviews.rs
@@ -2,8 +2,8 @@ use crate::{
     errors::{AppError, Result},
     middleware::auth::AuthUser,
     routes::support::{
-        eq, limit, normalize_review, offset, order, q, select_all, unwrap_rpc_items, value_str,
-        QueryParams,
+        eq, limit, normalize_review, offset, order, pagination_headers, pagination_meta,
+        pagination_window, q, select_all, unwrap_rpc_items, value_str, QueryParams,
     },
     security,
     state::AppState,
@@ -15,7 +15,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::sync::Arc;
@@ -35,6 +35,8 @@ pub fn router() -> Router<Arc<AppState>> {
 struct PaginationParams {
     limit: Option<i64>,
     offset: Option<i64>,
+    cursor: Option<String>,
+    include_pagination: Option<bool>,
 }
 
 async fn list_business_reviews(
@@ -43,15 +45,22 @@ async fn list_business_reviews(
     Query(params): Query<PaginationParams>,
 ) -> Result<impl IntoResponse> {
     let business_id = security::validate_uuid_id(&business_id, "business ID")?;
+    let window = pagination_window(
+        params.limit,
+        params.offset,
+        params.cursor.as_deref(),
+        20,
+        100,
+    )?;
     let query: QueryParams = vec![
         select_all(),
         eq("business_id", business_id),
         order("created_at.desc"),
-        limit(params.limit.unwrap_or(20).clamp(1, 100)),
-        offset(params.offset.unwrap_or(0)),
+        limit(window.limit + 1),
+        offset(window.offset),
     ];
 
-    let reviews = state
+    let mut reviews = state
         .db
         .supabase
         .select_json("reviews", &query)
@@ -59,8 +68,21 @@ async fn list_business_reviews(
         .into_iter()
         .map(normalize_review)
         .collect::<Vec<_>>();
+    let meta = pagination_meta(window.limit, window.offset, reviews.len());
+    reviews.truncate(window.limit as usize);
 
-    Ok(Json(reviews))
+    let body = if params.include_pagination.unwrap_or(false) {
+        json!({
+            "items": reviews,
+            "pagination": &meta,
+            "has_more": meta.has_more,
+            "next_cursor": meta.next_cursor.clone(),
+        })
+    } else {
+        json!(reviews)
+    };
+
+    Ok((pagination_headers(&meta), Json(body)))
 }
 
 async fn get_review(
@@ -111,6 +133,7 @@ async fn create_review(
             "You have already reviewed this business".into(),
         ));
     }
+    ensure_review_rate_allowed(&state, &auth_user.id).await?;
 
     let now = Utc::now().to_rfc3339();
     let mut body = Map::new();
@@ -134,7 +157,8 @@ async fn create_review(
         .db
         .supabase
         .insert_json("reviews", Value::Object(body))
-        .await?;
+        .await
+        .map_err(map_review_insert_error)?;
 
     update_business_rating(&state, &business_id).await?;
 
@@ -167,6 +191,7 @@ async fn update_review(
         .await?
         .ok_or_else(|| AppError::NotFound("Business not found".into()))?;
     ensure_not_owned_business_review(&business, &auth_user)?;
+    ensure_review_update_rate_allowed(&state, &auth_user.id, &id).await?;
 
     let mut body = Map::new();
     body.insert("updated_at".into(), json!(Utc::now().to_rfc3339()));
@@ -322,6 +347,53 @@ fn ensure_not_owned_business_review(business: &Value, auth_user: &AuthUser) -> R
         ));
     }
     Ok(())
+}
+
+async fn ensure_review_rate_allowed(state: &AppState, user_id: &str) -> Result<()> {
+    let since = (Utc::now() - Duration::hours(1)).to_rfc3339();
+    let recent = state
+        .db
+        .supabase
+        .count(
+            "reviews",
+            &[
+                eq("user_id", user_id),
+                crate::routes::support::gte("created_at", since),
+            ],
+        )
+        .await?;
+    if recent >= 8 {
+        return Err(AppError::RateLimited);
+    }
+    Ok(())
+}
+
+async fn ensure_review_update_rate_allowed(
+    state: &AppState,
+    user_id: &str,
+    review_id: &str,
+) -> Result<()> {
+    let allowed = state
+        .rate_limiter
+        .check(
+            &format!("review-update:{}:{}", user_id, review_id),
+            8,
+            std::time::Duration::from_secs(3600),
+        )
+        .await;
+    if !allowed {
+        return Err(AppError::RateLimited);
+    }
+    Ok(())
+}
+
+fn map_review_insert_error(err: anyhow::Error) -> AppError {
+    let message = err.to_string().to_ascii_lowercase();
+    if message.contains("duplicate") || message.contains("unique") {
+        AppError::Conflict("You have already reviewed this business".into())
+    } else {
+        err.into()
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/routes/saved.rs
+++ b/backend/src/routes/saved.rs
@@ -1,19 +1,23 @@
 use crate::{
     errors::{AppError, Result},
     middleware::auth::AuthUser,
-    routes::support::{eq, normalize_business, order, q, select_all, value_str},
+    routes::support::{
+        eq, limit, normalize_business, order, pagination_headers, pagination_meta,
+        pagination_window, q, select_all, value_str,
+    },
     security,
     state::AppState,
 };
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
 use chrono::Utc;
+use serde::Deserialize;
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new().route("/saved", get(list_saved)).route(
@@ -22,11 +26,27 @@ pub fn router() -> Router<Arc<AppState>> {
     )
 }
 
+#[derive(Deserialize)]
+struct SavedParams {
+    limit: Option<i64>,
+    offset: Option<i64>,
+    cursor: Option<String>,
+    include_pagination: Option<bool>,
+}
+
 async fn list_saved(
     State(state): State<Arc<AppState>>,
     auth_user: AuthUser,
+    Query(params): Query<SavedParams>,
 ) -> Result<impl IntoResponse> {
-    let saved = state
+    let window = pagination_window(
+        params.limit,
+        params.offset,
+        params.cursor.as_deref(),
+        50,
+        100,
+    )?;
+    let mut saved = state
         .db
         .supabase
         .select_json(
@@ -35,28 +55,44 @@ async fn list_saved(
                 select_all(),
                 eq("user_id", &auth_user.id),
                 order("created_at.desc"),
+                limit(window.limit + 1),
+                crate::routes::support::offset(window.offset),
             ],
         )
         .await?;
+    let meta = pagination_meta(window.limit, window.offset, saved.len());
+    saved.truncate(window.limit as usize);
+
+    let business_ids = saved
+        .iter()
+        .filter_map(|row| {
+            let id = value_str(row, "business_id");
+            (!id.is_empty()).then(|| id.to_string())
+        })
+        .collect::<Vec<_>>();
+    let businesses = fetch_businesses_by_ids(&state, &business_ids).await?;
 
     let mut items = Vec::new();
-    for saved_row in saved {
-        let business_id = value_str(&saved_row, "business_id");
-        if business_id.is_empty() {
-            continue;
-        }
-        if let Some(mut business) = state
-            .db
-            .supabase
-            .select_one_json("businesses", &[select_all(), eq("id", business_id)])
-            .await?
-        {
+    for saved_row in &saved {
+        let business_id = value_str(saved_row, "business_id");
+        if let Some(mut business) = businesses.get(business_id).cloned() {
             business["saved_at"] = saved_row.get("created_at").cloned().unwrap_or(Value::Null);
             items.push(normalize_business(business));
         }
     }
 
-    Ok(Json(json!({ "items": items })))
+    let body = if params.include_pagination.unwrap_or(false) {
+        json!({
+            "items": items,
+            "pagination": &meta,
+            "has_more": meta.has_more,
+            "next_cursor": meta.next_cursor.clone(),
+        })
+    } else {
+        json!({ "items": items })
+    };
+
+    Ok((pagination_headers(&meta), Json(body)))
 }
 
 async fn save_business(
@@ -98,7 +134,8 @@ async fn save_business(
                     "created_at": Utc::now().to_rfc3339(),
                 }),
             )
-            .await?;
+            .await
+            .map_err(map_save_insert_error)?;
     }
 
     Ok(Json(json!({ "saved": true, "business_id": business_id })))
@@ -110,7 +147,7 @@ async fn unsave_business(
     Path(business_id): Path<String>,
 ) -> Result<impl IntoResponse> {
     let business_id = security::validate_uuid_id(&business_id, "business ID")?;
-    state
+    let deleted = state
         .db
         .supabase
         .delete_json(
@@ -121,6 +158,55 @@ async fn unsave_business(
             ],
         )
         .await?;
+    if deleted.is_empty() {
+        return Err(AppError::NotFound("Saved business not found".into()));
+    }
 
     Ok(Json(json!({ "saved": false, "business_id": business_id })))
+}
+
+async fn fetch_businesses_by_ids(
+    state: &AppState,
+    business_ids: &[String],
+) -> Result<HashMap<String, Value>> {
+    if business_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut unique_ids = Vec::new();
+    for id in business_ids {
+        let id = security::validate_uuid_id(id, "business ID")?;
+        if !unique_ids.contains(&id) {
+            unique_ids.push(id);
+        }
+    }
+
+    let rows = state
+        .db
+        .supabase
+        .select_json(
+            "businesses",
+            &[
+                select_all(),
+                q("id", format!("in.({})", unique_ids.join(","))),
+            ],
+        )
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let id = value_str(&row, "id").to_string();
+            (!id.is_empty()).then_some((id, row))
+        })
+        .collect())
+}
+
+fn map_save_insert_error(err: anyhow::Error) -> AppError {
+    let message = err.to_string().to_ascii_lowercase();
+    if message.contains("duplicate") || message.contains("unique") {
+        AppError::Conflict("Business already saved".into())
+    } else {
+        err.into()
+    }
 }

--- a/backend/src/routes/subscriptions.rs
+++ b/backend/src/routes/subscriptions.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::{AppError, Result},
     middleware::auth::AuthUser,
-    routes::support::{eq, normalize_id_alias, order, select_all, value_str},
+    routes::support::{eq, normalize_id_alias, order, q, select_all, value_str},
     security,
     state::AppState,
 };
@@ -63,7 +63,7 @@ async fn get_tiers() -> impl IntoResponse {
             "description": "Analytics and publishing tools for growing teams.",
             "monthly_price": 29.99,
             "yearly_price": 287.90,
-            "features": ["Analytics", "Priority event placement", "Expanded media"],
+            "features": ["Analytics", "Expanded owner events", "Expanded media"],
             "highlighted": true
         },
         {
@@ -185,6 +185,7 @@ async fn create_subscription(
         let success_url = checkout_return_url(&state, "success");
         let cancel_url = checkout_return_url(&state, "cancel");
         let checkout = crate::services::stripe::create_checkout_session(
+            &state.stripe_http,
             crate::services::stripe::CheckoutSessionRequest {
                 secret_key: &state.config.stripe_secret_key,
                 email: &auth_user.email,
@@ -198,7 +199,7 @@ async fn create_subscription(
             },
         )
         .await
-        .map_err(|e| AppError::Internal(format!("Stripe error: {}", e)))?;
+        .map_err(|_| AppError::ServiceUnavailable("Stripe checkout is unavailable".into()))?;
 
         let checkout_url = checkout["url"]
             .as_str()
@@ -390,6 +391,19 @@ async fn stripe_webhook(
         "customer.subscription.deleted" => {
             cancel_stripe_subscription_from_webhook(&state, object).await?
         }
+        "invoice.payment_failed"
+        | "customer.subscription.past_due"
+        | "customer.subscription.unpaid" => {
+            mark_stripe_subscription_payment_problem(&state, object, event_type).await?
+        }
+        "customer.subscription.updated"
+            if matches!(
+                object["status"].as_str(),
+                Some("past_due" | "unpaid" | "incomplete_expired")
+            ) =>
+        {
+            mark_stripe_subscription_payment_problem(&state, object, event_type).await?
+        }
         _ => json!({ "status": "ignored", "event_type": event_type }),
     };
 
@@ -458,45 +472,14 @@ async fn activate_checkout_subscription(
         }));
     }
 
-    let active_for_business = state
-        .db
-        .supabase
-        .select_json(
-            "subscriptions",
-            &[
-                select_all(),
-                eq("user_id", &user_id),
-                eq("business_id", &business_id),
-                eq("status", "active"),
-            ],
-        )
-        .await?;
-    for active_subscription in &active_for_business {
-        cancel_stripe_subscription_if_needed(state, active_subscription).await?;
-    }
-
     let now = Utc::now().to_rfc3339();
-    state
-        .db
-        .supabase
-        .update_json(
-            "subscriptions",
-            &[
-                eq("user_id", &user_id),
-                eq("business_id", &business_id),
-                eq("status", "active"),
-            ],
-            json!({ "status": "canceled", "updated_at": now }),
-        )
-        .await?;
-
     let subscription_id = value_str(&subscription, "id").to_string();
     let updated = state
         .db
         .supabase
         .update_json(
             "subscriptions",
-            &[eq("id", &subscription_id)],
+            &[eq("id", &subscription_id), eq("status", "pending_checkout")],
             json!({
                 "status": "active",
                 "tier": tier,
@@ -508,10 +491,56 @@ async fn activate_checkout_subscription(
         )
         .await?;
 
-    let activated = updated
-        .into_iter()
-        .next()
-        .ok_or_else(|| AppError::Internal("Subscription activation updated no rows".into()))?;
+    let Some(activated) = updated.into_iter().next() else {
+        let current = state
+            .db
+            .supabase
+            .select_one_json("subscriptions", &[select_all(), eq("id", &subscription_id)])
+            .await?;
+        if let Some(current) = current {
+            refresh_auth_subscription_tier_from_active_subscriptions(state, &user_id).await?;
+            return Ok(json!({
+                "status": if value_str(&current, "status") == "active" { "already_active" } else { "ignored" },
+                "subscription": normalize_id_alias(current),
+            }));
+        }
+        return Err(AppError::Internal(
+            "Subscription activation updated no rows".into(),
+        ));
+    };
+
+    let active_for_business = state
+        .db
+        .supabase
+        .select_json(
+            "subscriptions",
+            &[
+                select_all(),
+                eq("user_id", &user_id),
+                eq("business_id", &business_id),
+                eq("status", "active"),
+                q("id", format!("neq.{}", subscription_id)),
+            ],
+        )
+        .await?;
+    for active_subscription in &active_for_business {
+        cancel_stripe_subscription_if_needed(state, active_subscription).await?;
+    }
+
+    state
+        .db
+        .supabase
+        .update_json(
+            "subscriptions",
+            &[
+                eq("user_id", &user_id),
+                eq("business_id", &business_id),
+                eq("status", "active"),
+                q("id", format!("neq.{}", subscription_id)),
+            ],
+            json!({ "status": "canceled", "updated_at": now }),
+        )
+        .await?;
 
     refresh_auth_subscription_tier_from_active_subscriptions(state, &user_id).await?;
 
@@ -586,13 +615,77 @@ async fn cancel_stripe_subscription_from_webhook(
     }))
 }
 
+async fn mark_stripe_subscription_payment_problem(
+    state: &AppState,
+    stripe_object: &Value,
+    event_type: &str,
+) -> Result<Value> {
+    let stripe_subscription_id = stripe_ref_id(&stripe_object["subscription"])
+        .or_else(|| stripe_ref_id(&stripe_object["id"]))
+        .ok_or_else(|| AppError::BadRequest("Stripe subscription id missing".into()))?;
+    let status = stripe_object["status"]
+        .as_str()
+        .filter(|value| matches!(*value, "past_due" | "unpaid" | "incomplete_expired"))
+        .unwrap_or("past_due");
+
+    let Some(subscription) = state
+        .db
+        .supabase
+        .select_one_json(
+            "subscriptions",
+            &[
+                select_all(),
+                eq("stripe_subscription_id", &stripe_subscription_id),
+                order("created_at.desc"),
+            ],
+        )
+        .await?
+    else {
+        return Ok(json!({
+            "status": "ignored",
+            "reason": "subscription_not_found",
+            "stripe_subscription_id": stripe_subscription_id,
+            "event_type": event_type,
+        }));
+    };
+
+    let user_id = security::validate_uuid_id(value_str(&subscription, "user_id"), "user ID")?;
+    let updated = state
+        .db
+        .supabase
+        .update_json(
+            "subscriptions",
+            &[eq("id", value_str(&subscription, "id"))],
+            json!({
+                "status": status,
+                "tier": "free",
+                "cancel_at_period_end": true,
+                "updated_at": Utc::now().to_rfc3339(),
+            }),
+        )
+        .await?;
+
+    let subscription = updated
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::Internal("Subscription payment status updated no rows".into()))?;
+
+    refresh_auth_subscription_tier_from_active_subscriptions(state, &user_id).await?;
+
+    Ok(json!({
+        "status": "payment_problem_marked",
+        "event_type": event_type,
+        "subscription": normalize_id_alias(subscription),
+    }))
+}
+
 fn price_id_for(tier: &str, billing_cycle: &str) -> Result<String> {
     let key = format!(
         "STRIPE_PRICE_{}_{}",
         tier.to_ascii_uppercase(),
         billing_cycle.to_ascii_uppercase()
     );
-    env::var(&key).map_err(|_| AppError::BadRequest(format!("{} is not configured", key)))
+    env::var(&key).map_err(|_| AppError::BadRequest("Pricing not available for this tier".into()))
 }
 
 fn checkout_return_url(state: &AppState, result: &str) -> String {
@@ -648,11 +741,17 @@ async fn cancel_stripe_subscription_if_needed(
         return Ok(());
     }
     if state.config.stripe_secret_key.is_empty() {
-        return Err(AppError::BadRequest("Stripe not configured".into()));
+        return Err(AppError::ServiceUnavailable(
+            "Stripe is not configured".into(),
+        ));
     }
-    crate::services::stripe::cancel_subscription(&state.config.stripe_secret_key, sub_id)
-        .await
-        .map_err(|_| AppError::BadRequest("Stripe subscription cancellation failed".into()))?;
+    crate::services::stripe::cancel_subscription(
+        &state.stripe_http,
+        &state.config.stripe_secret_key,
+        sub_id,
+    )
+    .await
+    .map_err(|_| AppError::ServiceUnavailable("Stripe subscription cancellation failed".into()))?;
     Ok(())
 }
 

--- a/backend/src/routes/support.rs
+++ b/backend/src/routes/support.rs
@@ -1,6 +1,11 @@
+use crate::{errors::AppError, errors::Result};
+use axum::http::{HeaderMap, HeaderValue};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde::Serialize;
 use serde_json::{json, Value};
 
 pub type QueryParams = Vec<(String, String)>;
+const CURSOR_PREFIX: &str = "offset:";
 
 pub fn q(key: impl Into<String>, value: impl Into<String>) -> (String, String) {
     (key.into(), value.into())
@@ -8,6 +13,10 @@ pub fn q(key: impl Into<String>, value: impl Into<String>) -> (String, String) {
 
 pub fn eq(column: &str, value: impl ToString) -> (String, String) {
     q(column, format!("eq.{}", value.to_string()))
+}
+
+pub fn gte(column: &str, value: impl ToString) -> (String, String) {
+    q(column, format!("gte.{}", value.to_string()))
 }
 
 pub fn is_true(column: &str) -> (String, String) {
@@ -28,6 +37,94 @@ pub fn offset(value: i64) -> (String, String) {
 
 pub fn order(value: &str) -> (String, String) {
     q("order", value)
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PaginationMeta {
+    pub limit: i64,
+    pub offset: i64,
+    pub has_more: bool,
+    pub next_offset: Option<i64>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaginationWindow {
+    pub limit: i64,
+    pub offset: i64,
+}
+
+pub fn pagination_window(
+    limit_value: Option<i64>,
+    offset_value: Option<i64>,
+    cursor_value: Option<&str>,
+    default_limit: i64,
+    max_limit: i64,
+) -> Result<PaginationWindow> {
+    let limit = limit_value.unwrap_or(default_limit).clamp(1, max_limit);
+    let offset_from_cursor = cursor_value
+        .filter(|value| !value.trim().is_empty())
+        .map(decode_offset_cursor)
+        .transpose()?;
+    let offset = offset_from_cursor.or(offset_value).unwrap_or(0).max(0);
+
+    Ok(PaginationWindow { limit, offset })
+}
+
+pub fn pagination_meta(limit: i64, offset: i64, fetched_count: usize) -> PaginationMeta {
+    let has_more = fetched_count > limit as usize;
+    let next_offset = has_more.then_some(offset + limit);
+    let next_cursor = next_offset.map(encode_offset_cursor);
+
+    PaginationMeta {
+        limit,
+        offset,
+        has_more,
+        next_offset,
+        next_cursor,
+    }
+}
+
+pub fn pagination_headers(meta: &PaginationMeta) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-page-limit",
+        HeaderValue::from_str(&meta.limit.to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("0")),
+    );
+    headers.insert(
+        "x-page-offset",
+        HeaderValue::from_str(&meta.offset.to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("0")),
+    );
+    headers.insert(
+        "x-has-more",
+        HeaderValue::from_static(if meta.has_more { "true" } else { "false" }),
+    );
+    if let Some(cursor) = &meta.next_cursor {
+        if let Ok(value) = HeaderValue::from_str(cursor) {
+            headers.insert("x-next-cursor", value);
+        }
+    }
+    headers
+}
+
+fn encode_offset_cursor(offset: i64) -> String {
+    URL_SAFE_NO_PAD.encode(format!("{}{}", CURSOR_PREFIX, offset.max(0)))
+}
+
+fn decode_offset_cursor(cursor: &str) -> Result<i64> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(cursor.trim())
+        .map_err(|_| AppError::BadRequest("Invalid pagination cursor".into()))?;
+    let decoded = String::from_utf8(decoded)
+        .map_err(|_| AppError::BadRequest("Invalid pagination cursor".into()))?;
+    let offset = decoded
+        .strip_prefix(CURSOR_PREFIX)
+        .ok_or_else(|| AppError::BadRequest("Invalid pagination cursor".into()))?
+        .parse::<i64>()
+        .map_err(|_| AppError::BadRequest("Invalid pagination cursor".into()))?;
+    Ok(offset.max(0))
 }
 
 pub fn ilike_or_filter(columns: &[&str], raw: &str) -> Option<(String, String)> {
@@ -190,5 +287,18 @@ mod tests {
         assert!(!geo_rpc_unavailable(
             "permission denied for table businesses"
         ));
+    }
+
+    #[test]
+    fn pagination_cursor_round_trips_offset_and_rejects_bad_values() {
+        let meta = pagination_meta(20, 40, 21);
+        assert!(meta.has_more);
+        assert_eq!(meta.next_offset, Some(60));
+
+        let window = pagination_window(None, None, meta.next_cursor.as_deref(), 10, 50).unwrap();
+        assert_eq!(window.limit, 10);
+        assert_eq!(window.offset, 60);
+
+        assert!(pagination_window(None, None, Some("not-a-cursor"), 10, 50).is_err());
     }
 }

--- a/backend/src/routes/users.rs
+++ b/backend/src/routes/users.rs
@@ -47,8 +47,8 @@ async fn update_me(
         set_metadata(&mut user_metadata, "name", json!(cleaned));
     }
     if let Some(profile_picture) = payload["profile_picture"].as_str() {
-        if let Some(cleaned) = security::sanitize_optional_text(Some(profile_picture), 500) {
-            set_metadata(&mut user_metadata, "profile_picture", json!(cleaned));
+        if let Some(url) = security::normalize_url(Some(profile_picture), 500, false)? {
+            set_metadata(&mut user_metadata, "profile_picture", json!(url));
         }
     }
     if let Some(about_me) = payload["about_me"].as_str() {

--- a/backend/src/security.rs
+++ b/backend/src/security.rs
@@ -114,7 +114,11 @@ pub fn normalize_url(
 
 pub fn validate_photo_reference(value: &str) -> Result<String> {
     let cleaned = sanitize_text(value, 512);
-    if cleaned.is_empty() || cleaned.len() > 512 || !PHOTO_REF_RE.is_match(&cleaned) {
+    if cleaned.is_empty()
+        || cleaned.len() > 512
+        || cleaned.contains("..")
+        || !PHOTO_REF_RE.is_match(&cleaned)
+    {
         return Err(AppError::BadRequest("Invalid photo reference".into()));
     }
     Ok(cleaned)
@@ -296,6 +300,12 @@ mod tests {
     fn uuid_validation_rejects_bad_ids() {
         assert!(validate_uuid_id("not-a-uuid", "business ID").is_err());
         assert!(validate_uuid_id("550e8400-e29b-41d4-a716-446655440000", "business ID").is_ok());
+    }
+
+    #[test]
+    fn photo_reference_rejects_parent_path_segments() {
+        assert!(super::validate_photo_reference("safe_photo-ref.1").is_ok());
+        assert!(super::validate_photo_reference("unsafe..photo").is_err());
     }
 
     #[test]

--- a/backend/src/services/google_places.rs
+++ b/backend/src/services/google_places.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
+use reqwest::Client;
 use serde_json::Value;
 
 const PLACES_API: &str = "https://maps.googleapis.com/maps/api/place";
-const GOOGLE_HTTP_TIMEOUT_SECS: u64 = 10;
 
 pub async fn search_nearby(
+    client: &Client,
     api_key: &str,
     lat: f64,
     lng: f64,
@@ -20,30 +21,30 @@ pub async fn search_nearby(
         url.push_str(&format!("&keyword={}", urlencoding::encode(kw)));
     }
 
-    let resp = get_google_json(&url).await?;
+    let resp = get_google_json(client, &url).await?;
 
     let results = resp["results"].as_array().cloned().unwrap_or_default();
 
     Ok(results)
 }
 
-pub async fn get_place_details(api_key: &str, place_id: &str) -> Result<Value> {
+pub async fn get_place_details(client: &Client, api_key: &str, place_id: &str) -> Result<Value> {
     let url = format!(
         "{}/details/json?place_id={}&fields=name,formatted_address,geometry,rating,user_ratings_total,opening_hours,photos,price_level,website,formatted_phone_number&key={}",
         PLACES_API, place_id, api_key
     );
 
-    let resp = get_google_json(&url).await?;
+    let resp = get_google_json(client, &url).await?;
     Ok(resp["result"].clone())
 }
 
-pub async fn reverse_geocode(api_key: &str, lat: f64, lng: f64) -> Result<Value> {
+pub async fn reverse_geocode(client: &Client, api_key: &str, lat: f64, lng: f64) -> Result<Value> {
     let url = format!(
         "https://maps.googleapis.com/maps/api/geocode/json?latlng={},{}&key={}",
         lat, lng, api_key
     );
 
-    get_google_json(&url).await
+    get_google_json(client, &url).await
 }
 
 pub async fn get_photo_url(api_key: &str, photo_reference: &str, max_width: u32) -> String {
@@ -53,14 +54,8 @@ pub async fn get_photo_url(api_key: &str, photo_reference: &str, max_width: u32)
     )
 }
 
-pub fn google_http_client() -> Result<reqwest::Client> {
-    Ok(reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(GOOGLE_HTTP_TIMEOUT_SECS))
-        .build()?)
-}
-
-async fn get_google_json(url: &str) -> Result<Value> {
-    let resp = google_http_client()?.get(url).send().await?;
+async fn get_google_json(client: &Client, url: &str) -> Result<Value> {
+    let resp = client.get(url).send().await?;
     let status = resp.status();
     let data: Value = resp.json().await?;
     if !status.is_success() {

--- a/backend/src/services/recaptcha.rs
+++ b/backend/src/services/recaptcha.rs
@@ -1,8 +1,10 @@
 use crate::config::Config;
 use anyhow::{bail, Result};
+use reqwest::Client;
 use serde_json::Value;
 
 pub async fn verify_recaptcha_token(
+    client: &Client,
     config: &Config,
     token: &str,
     expected_action: &str,
@@ -23,12 +25,6 @@ pub async fn verify_recaptcha_token(
             "expectedAction": expected_action,
         }
     });
-
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(
-            config.recaptcha_verify_timeout_secs,
-        ))
-        .build()?;
 
     let resp: Value = client.post(&url).json(&body).send().await?.json().await?;
 

--- a/backend/src/services/stripe.rs
+++ b/backend/src/services/stripe.rs
@@ -1,10 +1,15 @@
 use anyhow::Result;
+use reqwest::Client;
 use serde_json::{json, Value};
 
 const STRIPE_API: &str = "https://api.stripe.com/v1";
 
-async fn stripe_post(secret_key: &str, path: &str, params: &[(&str, &str)]) -> Result<Value> {
-    let client = stripe_client()?;
+async fn stripe_post(
+    client: &Client,
+    secret_key: &str,
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<Value> {
     let resp = client
         .post(format!("{}{}", STRIPE_API, path))
         .basic_auth(secret_key, Option::<&str>::None)
@@ -37,8 +42,7 @@ async fn parse_stripe_response(resp: reqwest::Response) -> Result<Value> {
     Ok(data)
 }
 
-async fn stripe_delete(secret_key: &str, path: &str) -> Result<Value> {
-    let client = stripe_client()?;
+async fn stripe_delete(client: &Client, secret_key: &str, path: &str) -> Result<Value> {
     let resp = client
         .delete(format!("{}{}", STRIPE_API, path))
         .basic_auth(secret_key, Option::<&str>::None)
@@ -48,8 +52,17 @@ async fn stripe_delete(secret_key: &str, path: &str) -> Result<Value> {
     parse_stripe_response(resp).await
 }
 
-pub async fn cancel_subscription(secret_key: &str, subscription_id: &str) -> Result<Value> {
-    stripe_delete(secret_key, &format!("/subscriptions/{}", subscription_id)).await
+pub async fn cancel_subscription(
+    client: &Client,
+    secret_key: &str,
+    subscription_id: &str,
+) -> Result<Value> {
+    stripe_delete(
+        client,
+        secret_key,
+        &format!("/subscriptions/{}", subscription_id),
+    )
+    .await
 }
 
 pub struct CheckoutSessionRequest<'a> {
@@ -64,8 +77,12 @@ pub struct CheckoutSessionRequest<'a> {
     pub billing_cycle: &'a str,
 }
 
-pub async fn create_checkout_session(request: CheckoutSessionRequest<'_>) -> Result<Value> {
+pub async fn create_checkout_session(
+    client: &Client,
+    request: CheckoutSessionRequest<'_>,
+) -> Result<Value> {
     stripe_post(
+        client,
         request.secret_key,
         "/checkout/sessions",
         &[
@@ -92,10 +109,4 @@ pub async fn create_checkout_session(request: CheckoutSessionRequest<'_>) -> Res
         ],
     )
     .await
-}
-
-fn stripe_client() -> Result<reqwest::Client> {
-    Ok(reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(15))
-        .build()?)
 }

--- a/backend/src/services/visibility_score.rs
+++ b/backend/src/services/visibility_score.rs
@@ -6,18 +6,10 @@ use serde_json::Value;
 /// - Average rating (0-5) weighted by review count
 /// - Review count (log-scaled)
 /// - Whether the business is verified
-/// - Stored visibility_score override (if already computed externally)
 ///
 /// Business claiming is intentionally excluded from the score. Ranking is
 /// earned by activity and credibility, never by ownership status.
 pub fn compute(row: &Value) -> f64 {
-    // Use stored score if available
-    if let Some(stored) = row.get("visibility_score").and_then(Value::as_f64) {
-        if stored > 0.0 {
-            return stored;
-        }
-    }
-
     let mut score: f64 = 0.0;
 
     // Rating signal (0-40 points)
@@ -118,5 +110,19 @@ mod tests {
         claimed["is_claimed"] = json!(true);
 
         assert_eq!(compute(&unclaimed), compute(&claimed));
+    }
+
+    #[test]
+    fn stored_visibility_score_does_not_override_organic_signals() {
+        let row = json!({
+            "visibility_score": 99.0,
+            "rating": 5.0,
+            "review_count": 0,
+            "is_verified": false,
+            "description": "",
+            "photos": [],
+        });
+
+        assert_eq!(compute(&row), 0.0);
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,8 +1,31 @@
 use crate::{config::Config, db::Database, security::RateLimiter};
+use reqwest::Client;
 
 #[derive(Clone)]
 pub struct AppState {
     pub config: Config,
     pub db: Database,
     pub rate_limiter: RateLimiter,
+    pub google_http: Client,
+    pub stripe_http: Client,
+    pub recaptcha_http: Client,
+}
+
+impl AppState {
+    pub fn new(config: Config, db: Database) -> anyhow::Result<Self> {
+        Ok(Self {
+            google_http: http_client(10)?,
+            stripe_http: http_client(15)?,
+            recaptcha_http: http_client(config.recaptcha_verify_timeout_secs)?,
+            config,
+            db,
+            rate_limiter: RateLimiter::new(),
+        })
+    }
+}
+
+fn http_client(timeout_secs: u64) -> anyhow::Result<Client> {
+    Ok(Client::builder()
+        .timeout(std::time::Duration::from_secs(timeout_secs.max(1)))
+        .build()?)
 }

--- a/docs/AUDIT_REPORT.md
+++ b/docs/AUDIT_REPORT.md
@@ -1,6 +1,6 @@
 # Vantage Full-Stack Audit Report
 
-Last updated: May 21, 2026
+Last updated: June 11, 2026 (Pass 4 — re-read of routes: reviews, deals, subscriptions, saved, claims, location; and services: stripe, google_places)
 
 ## Scope Covered This Pass
 
@@ -300,10 +300,16 @@ overflow writes with a shared stacked scroll-lock hook for overlays.
 - Required business create/update, discovery, nearby, activity pulse, and owner
   event coordinate inputs to provide latitude/longitude as a complete valid
   pair instead of silently ignoring partial location filters.
+- Added cursor pagination metadata for business, review, activity feed, and
+  activity comment reads while preserving legacy default response bodies.
+- Replaced full-row business activity summary loads with PostgREST counts and a
+  single latest-check-in lookup.
 - Made business rating/review-count aggregate updates fail loudly instead of
   silently ignoring Supabase write failures.
 - Made business deal badge updates fail loudly and recompute after deal
   activation changes or deletion.
+- Added baseline abuse guards for repeated check-ins, high-frequency review
+  creation, repeated comments, and rapid activity likes/comments/posts.
 - Removed unused Redis/governor/nonzero dependencies and unused config/env
   fields.
 - Preserved the LVS invariant that claim status is not a ranking input.
@@ -342,8 +348,11 @@ overflow writes with a shared stacked scroll-lock hook for overlays.
 - Replaced direct body overflow mutations in the modal and mobile header drawer
   with a shared scroll-lock hook so overlapping overlays do not unlock page
   scrolling out of order.
-- Removed unused public Supabase and Stripe frontend env variables from the
-  example env file.
+- Added Supabase Realtime subscriptions for feed items, feed comments, and
+  owner events, enabled only when public Supabase realtime env vars are set.
+- Removed unused public Stripe frontend env variables from the example env file.
+- Reintroduced the public Supabase URL/anon-key frontend env vars as optional
+  realtime-only configuration.
 - Verified current API client route calls compile and bundle.
 
 ### Database
@@ -391,7 +400,7 @@ npm audit --audit-level=high
 Current verified result:
 
 - Rust backend and Vercel API wrapper compile.
-- Backend unit tests pass: 37 passed, including the LVS claim-status invariant.
+- Backend unit tests pass: 46 passed, including the LVS claim-status invariant.
 - Backend unit tests pass for LVS, Supabase JWT verification, UUID validation,
   public profile privacy, credibility-tier frontend contract, route
   construction, invalid business IDs, invalid user IDs, and invalid coordinates.
@@ -402,6 +411,10 @@ Current verified result:
   fallback helpers, owner self-review prevention, and complete check-in
   coordinate validation, deal expiry filtering, and current-deal PostgREST
   filter construction.
+- Backend unit tests now also cover protected-route auth requirements,
+  owner-only route rejection for customer tokens, malformed saved/review/check-in
+  subscription/activity-feed request contracts, local deployment smoke routes,
+  Vercel API/SPA rewrites, and pagination cursor helpers.
 - Backend router construction test passes, catching route alias conflicts.
 - Backend Clippy passes with `-D warnings`.
 - Frontend lint passes.
@@ -415,21 +428,411 @@ Current verified result:
 - `npx vercel build` was attempted but could not run without linked local Vercel
   project settings. Vercel reported `project_settings_required`.
 
-## Remaining Risks and Recommendations
+## Pass 2 — Full File-by-File Backend Audit (June 2026)
 
-- Apply the Supabase migrations to the actual Supabase project and run smoke
-  tests against live tables, including PostGIS radius RPCs, review-summary RPC,
-  and deal-status trigger/RPC behavior.
-- Verify Supabase Google provider configuration in the target project because
-  backend Google login now uses Supabase `id_token` sign-in rather than local
-  Google token verification.
-- Add integration tests for protected routes and owner/admin authorization.
-- Smoke-test signed Stripe webhook delivery against the deployed
-  `/api/stripe/webhook` endpoint.
-- Smoke-test PostGIS-backed `/api/businesses/nearby`, `/api/discover`,
-  `/api/activity/pulse`, and `/api/events` radius reads after migration apply.
-- Connect frontend realtime subscriptions for feed/comments/events.
-- Add abuse detection for suspicious reviews, check-ins, and likes.
-- Add route-level contract tests so frontend API paths cannot drift from backend
-  route mounting again.
+All 40 source files in `backend/src/` and `api/` were read and reviewed. No
+multi-agent tooling was used; every file was read sequentially. Findings are
+listed by severity.
+
+### Critical — Broken by Default
+
+**All domain models use `#[serde(rename = "_id")]` on `id`**
+Files: `models/business.rs:73`, `models/user.rs:46`, `models/review.rs:7`,
+`models/subscription.rs:57`, `models/activity.rs:16,30,49`,
+`models/claim.rs:24`, `models/deal.rs:7`, `models/saved.rs:6`.
+Supabase columns are named `id`, not `_id`. These structs fail to deserialize
+any DB row. `id` is always `None` in any response that uses these types directly.
+The `normalize_id_alias` helper patches this only in `Value`-based JSON paths.
+
+**`visibility_score::compute` stored-override early return**
+File: `services/visibility_score.rs:15–18`.
+If `visibility_score > 0` exists in the DB row, the function returns it
+verbatim, skipping ALL organic signal computation. One non-zero DB value
+permanently freezes a business's LVS rank. No unit test covers this path.
+
+**`create_business` sets `owner_id` and `is_claimed: false` simultaneously**
+File: `routes/businesses.rs`.
+`ensure_business_open_for_claim_submission` rejects claims when `owner_id` is
+non-null. Owner-created listings can never be claimed via the claims workflow.
+
+**`max_deals()` subscription limit never enforced**
+Files: `models/subscription.rs:33–40`, `routes/deals.rs`.
+Per-tier deal limits are modelled but `create_deal` never calls `max_deals()`.
+Free-tier businesses can create unlimited deals.
+
+**`visibility_boost`/`featured_placement` advertised but never applied**
+File: `models/subscription.rs:46–52`.
+`TierInfo` responses tell PRO/PREMIUM subscribers they receive visibility boosts
+that `visibility_score::compute()` never applies. False advertising and an
+LVS-invariant trap for future developers.
+
+### Security
+
+**Session cookie overwrites valid Bearer token**
+File: `middleware/auth.rs:121–122`.
+When a request carries both `Authorization: Bearer <valid>` and a stale
+`session=` cookie, the cookie value overwrites the already-extracted
+`access_token`. The valid Bearer token is silently discarded.
+
+**Rate limiter uses leftmost (client-controlled) X-Forwarded-For IP**
+File: `middleware/rate_limit.rs:51`.
+`.split(',').next()` takes the first IP in the header, which the client
+controls. Rate limiting is bypassed by prepending a spoofed IP.
+
+**`is_localhost` trusts the client-supplied `Host` header**
+File: `middleware/security_headers.rs:10–25`.
+Sending `Host: localhost` from any origin disables HSTS, X-Frame-Options,
+X-Content-Type-Options, and all other security headers in production.
+
+**Dev CORS origins are unconditionally trusted with credentials in production**
+File: `config.rs`.
+`localhost:5173`, `:3000`, `:5174`, and every `VERCEL_URL` preview URL are in
+the CORS allowlist combined with `allow_credentials(true)`. No environment guard.
+
+**Logout does not revoke Supabase tokens**
+File: `routes/auth.rs:111–117`.
+Only cookies are cleared. A stolen refresh token remains valid for up to 7 days.
+
+**JWT `nbf` (not-before) claim not verified**
+File: `jwt.rs:116–126`.
+`parse_claims` checks `exp` but never `nbf`. A token with a future `nbf` is
+accepted immediately.
+
+**`PHOTO_REF_RE` regex allows `..` path traversal**
+File: `security.rs`.
+The `.` character class matches any character, permitting `../..` in photo
+references passed to the Google photo proxy.
+
+**Raw Supabase error strings returned to HTTP clients**
+File: `errors.rs`.
+`AppError::Internal(msg)` and `AppError::DatabaseUnavailable(msg)` return raw
+error text, potentially exposing Supabase table names and constraint names.
+
+### Race Conditions (TOCTOU)
+
+**Duplicate review creation**
+File: `routes/reviews.rs:119–134`.
+Duplicate check and insert are separate DB calls. Two concurrent requests both
+see no existing review and both insert.
+
+**Stripe webhook duplicate activation**
+File: `routes/subscriptions.rs:415–521`.
+Activation is a non-atomic 4-step sequence (read → check → cancel → activate).
+Stripe's at-least-once delivery creates two concurrent active subscriptions.
+
+**Duplicate saved-business records**
+File: `routes/saved.rs:77–102`.
+Check and insert are separate calls. Concurrent saves create duplicate rows.
+
+**Claim re-review / non-atomic ownership transfer**
+File: `routes/claims.rs:168–215`.
+Already-approved claims can be re-reviewed. Claim approval reads and writes
+business ownership in two separate operations.
+
+### N+1 Queries and Performance
+
+**`list_saved` N+1**
+File: `routes/saved.rs:43–57`.
+One `select_one_json` call per saved business. No pagination limit on the
+initial query.
+
+**`get_activity_pulse` N+1**
+File: `routes/activity.rs:438–480`.
+`find_business` called inside the pulse-items loop — up to 90 sequential
+round-trips per request.
+
+**`list_owner_events` N+1**
+File: `routes/activity.rs:651–673`.
+`find_business` called per event — up to 100 sequential round-trips.
+
+**HTTP clients created per external API call**
+Files: `services/stripe.rs:97–101`, `services/google_places.rs:56–60`,
+`services/recaptcha.rs:27–31`.
+A new `reqwest::Client` (and TLS connection pool) is created for every
+Stripe, Google Places, and reCAPTCHA call. Should be shared via `AppState`.
+
+### Logic and Behaviour Bugs
+
+**`/decide` always returns 5 results regardless of `limit` parameter**
+File: `routes/discovery.rs:150+163`.
+`params.limit` is multiplied by 5 for over-fetching, then
+`rows.truncate(params.limit.unwrap_or(15).min(5))` uses the already-multiplied
+value. The user's `limit` is discarded.
+
+**`/explore/lanes` inherits caller's `q`/`search` across all 5 lanes**
+File: `routes/discovery.rs:118–139`.
+Lane params are cloned from user request params without clearing text search
+fields. `?q=keyword` distorts all 5 curated lanes.
+
+**`passes_decide_constraints` OPEN_NOW defaults to true when field absent**
+File: `routes/discovery.rs:390`.
+`open_now` absent from a DB row defaults to `true`. Businesses without hours
+data pass the OPEN_NOW filter and appear as open.
+
+**`discover_rows_geo` uses `match Some(sort) { Some("distance") => ... }`**
+File: `routes/discovery.rs:338–371`.
+`sort` is a `&str`. Wrapping it in `Some()` is always `Some`. The match works
+by accident; the outer `Some` wrapper is dead.
+
+**Google geocoding errors map to 400 Bad Request**
+File: `routes/location.rs:49`.
+Any upstream failure (rate limit, auth, network) becomes a 400, misleading
+clients into thinking their coordinates were invalid. Should be 502/503.
+
+**`DealUpdate` and `BusinessUpdate` have no validation**
+Files: `models/deal.rs:37–47`, `models/business.rs:121–134`.
+Update structs lack `#[derive(Validate)]`. Title can be set to empty,
+`discount_percent` to any value, and addresses are unbounded on update.
+
+**`BusinessCreate.address` has no max length**
+File: `models/business.rs:108`.
+`#[validate(length(min = 1))]` with no `max`. Multi-MB address strings are
+accepted and stored.
+
+**`select_one<T>` returns last row; `select_one_json` returns first**
+File: `db/supabase.rs:348`.
+`select_one<T>` calls `results.pop()` (last element). `select_one_json` calls
+`.next()` (first). Callers using the two methods against the same table may get
+different rows.
+
+**`unsave_business` silently returns success when no row exists**
+File: `routes/saved.rs`.
+`delete_json` succeeds even when no matching row was deleted. Always returns
+`{"saved": false}`.
+
+**`registration` partial failure leaves orphaned Supabase account**
+File: `routes/auth.rs:62–85`.
+If `update_registration_metadata` fails after `auth_create_user` succeeds, the
+account exists without role/tier metadata. User cannot re-register (duplicate
+email) and cannot log in correctly. No rollback path.
+
+### Files with No New Findings
+
+`backend/src/state.rs`, `backend/src/main.rs`, `api/index.rs`,
+`backend/src/services/geo_service.rs`, `backend/src/routes/mod.rs`,
+`backend/src/services/mod.rs`, `backend/src/middleware/mod.rs`,
+`backend/src/db/mod.rs`.
+
+---
+
+## Pass 3 — Auth, Config, Security, and Supporting Layers (June 2026)
+
+Pass 3 re-read `middleware/auth.rs`, `middleware/security_headers.rs`,
+`middleware/rate_limit.rs`, `config.rs`, `security.rs`, `errors.rs`,
+`jwt.rs`, `routes/auth.rs`, `routes/users.rs`, `routes/businesses.rs`,
+`models/business.rs`, `models/user.rs`, `services/recaptcha.rs`,
+`db/supabase.rs`, `api/index.rs`, and `state.rs`.
+
+### Security
+
+**`constant_time_eq` replaces `ring::constant_time::verify_slices_are_equal`**
+File: `jwt.rs:131–139`.
+The inline fold uses `acc | (x ^ y)`. LLVM can theoretically short-circuit this
+without assembly barriers. `ring` is already a dependency (ES256 still uses it)
+so the replacement gives no benefit and introduces a potential timing side-channel
+for HS256 signature verification. Should revert to `ring::constant_time`.
+
+**`parse_claims` error messages can leak JWT claim structure**
+File: `jwt.rs:117,128`.
+`format!("Invalid JWT claims: {}", e)` where `e` is a serde deserialisation
+error. These messages include field names and byte offsets, telling an attacker
+which fields are expected. Should return a generic "Invalid token" message.
+
+**`proxy_google_photo` reads response body with no size limit**
+File: `routes/businesses.rs:368–371`.
+`response.bytes().await` loads the full Google image into memory without a
+`Content-Length` guard or byte cap. A slow Google response serving a 50 MB blob
+would exhaust serverless memory. Should limit to `MAX_RESPONSE_BODY_BYTES` or
+a sane photo cap (e.g., 8 MB).
+
+**`profile_picture` stored as arbitrary text, not a validated URL**
+File: `routes/users.rs:49–52`.
+`sanitize_optional_text(Some(profile_picture), 500)` strips HTML tags and
+control characters but does not validate URL scheme. A `javascript:alert(1)`
+string passes. If the frontend ever renders `profile_picture` as an `<a href>`,
+this is stored XSS. Should use `normalize_url(..., require_https: false)`.
+
+**Raw `anyhow::Error` messages returned to HTTP clients on 5xx**
+File: `errors.rs:66–75`.
+The `From<anyhow::Error>` impl calls `e.to_string()` and wraps it directly in
+`AppError::Internal` or `AppError::DatabaseUnavailable`, both of which include
+the raw text in the JSON response body. Supabase table names, constraint names,
+and URL fragments from DB errors reach the client. Should log the full error
+server-side and return a generic message to the client.
+
+**JWKS `refresh_jwks` TOCTOU: concurrent refresh under split locks**
+File: `db/supabase.rs:93–112`.
+Staleness is checked under a read lock (line 94) and the write lock is acquired
+separately (line 112). Between the two, multiple concurrent requests can all
+pass the minimum-refresh-interval guard and all fire a JWKS fetch. Under ES256
+load this hammers the Supabase JWKS endpoint. Fix with `RwLock::try_write`
+or a `Mutex`-gated atomic compare.
+
+### Logic and Behaviour Bugs
+
+**`DiscoveryMode` enum is a subset of the values `sanitize_preferences` accepts**
+Files: `models/user.rs:25–32`, `security.rs:204–206`.
+The `DiscoveryMode` enum has three variants (`Hyperlocal`, `Neighborhood`,
+`Citywide`). `sanitize_preferences` accepts six strings including `"new_places"`,
+`"trending"`, and `"trusted"`, which have no enum representation. These values
+are stored in user metadata and returned in responses with no enum to validate
+against.
+
+**`match Some(sort) { ... }` dead outer wrapper in `query_businesses_geo`**
+File: `routes/businesses.rs:539–555`.
+Identical to the pattern in `discovery.rs`. `sort` is a `&str`; wrapping it in
+`Some()` is always `Some`. The outer `Some` wrapper is dead and the `_ => {}`
+arm is unreachable for valid sort strings. Functionally harmless but confusing.
+
+### Correction to Pass 2
+
+**`recaptcha-not-configured` is a rejection token, not a bypass**
+File: `routes/auth.rs:43–44`.
+The filter `*token != "recaptcha-not-configured"` causes that specific string to
+fall through to `ok_or_else(|| AppError::BadRequest(...))`, blocking registration.
+It is not a bypass — it prevents a frontend placeholder from being sent to the
+reCAPTCHA API. Pass 2 summary incorrectly described this as a bypass.
+
+---
+
+## Pass 4 — Routes and Services Re-read (June 2026)
+
+Pass 4 re-read `routes/reviews.rs`, `routes/deals.rs`, `routes/subscriptions.rs`,
+`routes/saved.rs`, `routes/claims.rs`, `routes/location.rs`, `services/stripe.rs`,
+`services/google_places.rs`, and `middleware/rate_limit.rs`.
+
+### Security
+
+**Stripe price-ID env var name exposed in 400 error response**
+File: `routes/subscriptions.rs:595`.
+`env::var(&key).map_err(|_| AppError::BadRequest(format!("{} is not configured", key)))` —
+`key` is constructed from the tier and billing cycle (e.g.,
+`STRIPE_PRICE_PRO_MONTHLY`). The env var name is returned to the client in
+the 400 response, revealing how the server's environment is structured.
+Should return a generic "Pricing not available for this tier" message.
+
+**`X-Forwarded-For` leftmost IP is client-controlled, but only as last resort**
+File: `middleware/rate_limit.rs:51`.
+The middleware checks `cf-connecting-ip` then `x-real-ip` before falling back to
+`x-forwarded-for`. On Vercel (which always injects `x-real-ip`), the
+`x-forwarded-for` fallback should rarely be reached. However, if the API is
+accessed directly, `x-forwarded-for` is controllable. The bypass works only
+without Cloudflare or Vercel's edge layer.
+
+### Logic and Behaviour Bugs
+
+**`create_deal` stores empty title after sanitization**
+File: `routes/deals.rs:134–137`.
+`security::sanitize_text(&payload.title, 200)` returns an empty string for
+empty or whitespace-only input. The result is inserted without a non-empty
+check. Deals with empty titles can be created and are displayed to users.
+Should validate that the sanitized title is non-empty.
+
+**`list_deals` and `list_business_deals` have no offset/cursor pagination**
+File: `routes/deals.rs:40–85`.
+Both handlers accept `limit` but no `offset` or cursor parameter. Users cannot
+page past the first page of results. The `PaginationParams` struct defines an
+`offset` field but the query builders never use it.
+
+Wait — re-reading: `PaginationParams` at line 35 only has `limit` and `offset`
+fields, but the `select_json` calls at lines 44–49 only push `limit(...)` —
+no `offset(...)`. Actually `PaginationParams` does include `offset: Option<i64>`
+(line 37), but it is never read. Dead field.
+
+**`update_review` has no rate limit**
+File: `routes/reviews.rs:173–220`.
+`create_review` calls `ensure_review_rate_allowed` (DB-backed, max 8/hour).
+`update_review` has no corresponding check. A user can submit rapid updates
+to a single review without restriction.
+
+**`review_claim` can change a settled claim's status to an inconsistent state**
+File: `routes/claims.rs:168–215`.
+There is no check that the claim is still `"pending"` before applying a status
+update. An admin who calls `review_claim` with `status: "rejected"` on an
+already-`"verified"` claim will flip the claim record to `"rejected"` while
+leaving `businesses.owner_id` set (the business update only runs on `"verified"`
+transitions). The claim says rejected; the business says claimed. Already noted
+in Pass 2 as a known gap; confirmed on re-read.
+
+**`my_claims` serialises the claims list under two keys**
+File: `routes/claims.rs:142`.
+`json!({ "items": claims, "claims": claims })` — the same borrowed vector is
+serialised twice into the response body (`serde_json::json!` borrows arguments).
+Clients receive the identical list under both `"items"` and `"claims"`, doubling
+the payload for no benefit.
+
+**`visibility_score::compute` stored-override path has no test coverage**
+File: `services/visibility_score.rs:15–18`.
+The unit test at line 109 never provides a row that already has a non-zero
+`visibility_score` field. The critical early-return bypass (the P0 bug that
+freezes LVS) is exercised by no test. A future fix could inadvertently break
+the organic path and tests would still pass.
+
+**`cancel_stripe_subscription_if_needed` returns 400 for Stripe API failures**
+File: `routes/subscriptions.rs:655`.
+`AppError::BadRequest("Stripe subscription cancellation failed")` is returned
+to the client when Stripe itself errors (rate limit, network, already-canceled).
+Should be `AppError::Internal` or a service-unavailable variant; 400 implies
+the caller made a mistake.
+
+**Stripe webhook does not handle payment failure lifecycle events**
+File: `routes/subscriptions.rs:386–394`.
+Only `checkout.session.completed` and `customer.subscription.deleted` are
+handled. `invoice.payment_failed`, `customer.subscription.past_due`, and
+`customer.subscription.unpaid` are silently ignored. A user whose recurring
+payment fails keeps paid feature access until Stripe definitively deletes the
+subscription (up to several retry cycles, typically 3–14 days).
+
+---
+
+## Remediation Status — June 12, 2026
+
+The P0/P1/P2 code findings listed above have been remediated in the current
+worktree:
+
+- Model structs now deserialize legacy `_id` via `alias` but serialize Supabase
+  `id`.
+- Owner-created businesses are owner-linked and claimed consistently.
+- `visibility_score::compute` no longer trusts stored score overrides, and a
+  regression test covers that path.
+- `X-Forwarded-For` fallback uses the rightmost IP, and security headers no
+  longer trust client-supplied `Host` to disable protections.
+- Deal creation enforces current-plan active deal limits, sanitized non-empty
+  titles, discount validation, and deal-list offsets.
+- Unwired visibility/featured placement advertising was removed from tier
+  metadata and pricing copy.
+- Stripe checkout activation is conditionally idempotent, logout attempts
+  Supabase token revocation, JWT `nbf` is enforced, and Bearer tokens take
+  precedence over stale cookies.
+- HS256 verification uses constant-time HMAC verification; JWT claim parse
+  failures return generic token errors.
+- Google photo proxy responses are size-capped, profile pictures must be URLs,
+  and 5xx/internal errors are logged server-side with sanitized client
+  responses.
+- JWKS refresh is mutex-gated, typed `select_one` now returns the first row,
+  and shared outbound `reqwest::Client`s live in `AppState`.
+- Saved businesses, activity pulse, and owner events batch-fetch businesses.
+- `/decide`, explore lanes, `OPEN_NOW`, `DiscoveryMode`, CORS origin handling,
+  claim review state, `my_claims`, review update throttling, Stripe price
+  lookup errors, Stripe cancellation errors, and payment-failure webhooks have
+  been corrected.
+
+Verification completed:
+
+- `cargo check`
+- `cargo test`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- `cd frontend && npm audit --audit-level=high`
+- `git diff --check`
+
+**Remaining external/infrastructure risks:**
+
+- Apply the Supabase migrations and verify PostGIS/RPC permissions in the
+  target Supabase project.
+- Run live deployment smoke tests for `/api/health`, `/api/discover`,
+  `/api/stripe/webhook`, `/api/auth/me`, Supabase Realtime, and SPA fallback
+  routes.
+- Smoke-test signed Stripe webhook delivery against the deployed endpoint.
 - Link or pull Vercel project settings locally, then rerun `npx vercel build`.

--- a/docs/NEXT_AGENT.md
+++ b/docs/NEXT_AGENT.md
@@ -1,6 +1,6 @@
 # Next Agent Handoff
 
-Last updated: May 21, 2026
+Last updated: June 12, 2026
 
 ## Safe Current State
 
@@ -15,6 +15,18 @@ Last updated: May 21, 2026
 - Recent backend consistency fixes are in place:
   - deal create/update/delete now refresh `businesses.has_deals`
   - activity-related write failures now propagate instead of being dropped
+  - route-level contract tests now cover unauthenticated protected routes,
+    owner-only authorization, malformed saved/review/check-in/subscription/feed
+    requests, local deployment smoke routes, and Vercel API/SPA rewrites
+  - business, review, feed, and activity-comment reads expose cursor pagination
+    metadata while preserving existing default response shapes
+  - business activity summaries use count queries instead of loading all
+    check-in/feed rows
+- Recent realtime and abuse fixes are in place:
+  - frontend feed items, feed comments, and owner events subscribe to Supabase
+    Realtime when `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are set
+  - repeated check-ins, high-frequency reviews, repeated comments, and rapid
+    activity likes/comments/posts have baseline abuse guards
 
 ## Verified Before Handoff
 
@@ -32,18 +44,12 @@ Known external blocker still reproduces:
 
 ## Remaining Checklist
 
-- Add route-level integration tests for auth, owner checks, saved businesses,
-  reviews, check-ins, subscriptions, and activity feed.
-- Add backend pagination/cursor contracts for high-volume feed, review,
-  business, and activity routes.
-- Add Supabase realtime subscriptions in the frontend for feed, comments, and
-  owner events.
-- Add abuse/fraud detection for repeated check-ins, suspicious review patterns,
-  and coordinated likes/comments.
-- Add deployment smoke tests for `/api/health`, `/api/discover`,
-  `/api/stripe/webhook`, `/api/auth/me`, and SPA fallback routes.
 - Apply and smoke-test the Supabase PostGIS, review-summary, and deal-status
   migrations in the target Supabase project.
+- Run live deployment smoke tests for `/api/health`, `/api/discover`,
+  `/api/stripe/webhook`, `/api/auth/me`, Supabase Realtime, and SPA fallback
+  routes against the target environment.
+- Smoke-test signed Stripe webhook delivery against the deployed endpoint.
 - Link or pull Vercel project settings locally, then rerun `npx vercel build`.
 
 ## External Completion Blockers
@@ -56,11 +62,9 @@ Known external blocker still reproduces:
 
 ## Suggested Next Moves
 
-1. Add protected-route integration coverage first; it gives the best signal for
-   auth, ownership, and subscription regressions.
-2. After tests, clear deployment blockers in order:
+1. Clear deployment blockers in order:
    - Supabase migrations + smoke tests
    - deployed Stripe webhook smoke
    - `vercel pull` / `npx vercel build`
-3. Only mark the goal complete after those external checks are evidenced, not
+2. Only mark the goal complete after those external checks are evidenced, not
    just after local green builds.

--- a/docs/PERFORMANCE_CHECKLIST.md
+++ b/docs/PERFORMANCE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Vantage Performance Checklist
 
-Audited: May 21, 2026
+Audited: June 12, 2026
 Stack: React 19 + Vite + Rust Axum + Supabase + Vercel Serverless
 
 ## Completed In Current Baseline
@@ -80,19 +80,24 @@ Stack: React 19 + Vite + Rust Axum + Supabase + Vercel Serverless
 - [x] Verified backend workspace compile.
 - [x] Verified backend Clippy with `-D warnings`.
 - [x] Verified high-severity npm audit reports 0 vulnerabilities.
+- [x] Added route-level contract tests for auth, owner-only guards, saved
+  businesses, reviews, check-ins, subscriptions, activity feed mutations,
+  deploy smoke endpoints, and Vercel SPA/API rewrites.
+- [x] Added cursor/metadata pagination contracts for business, review, feed,
+  and activity comment reads while preserving existing array responses by
+  default.
+- [x] Replaced unbounded business activity summary row loads with PostgREST
+  count queries plus a single latest-check-in lookup.
+- [x] Added frontend Supabase Realtime subscriptions for feed items, feed
+  comments, and owner events, gated behind optional public Supabase env vars.
+- [x] Added baseline abuse guards for repeated check-ins, high-frequency review
+  creation, repeated comments, and rapid activity likes/comments/posts.
 
 ## Highest Priority Remaining Work
 
-- [ ] Add route-level integration tests for auth, owner checks, saved businesses,
-  reviews, check-ins, subscriptions, and activity feed.
-- [ ] Add backend pagination/cursor contracts for high-volume feed, review,
-  business, and activity routes.
-- [ ] Add Supabase realtime subscriptions in the frontend for feed, comments,
-  and owner events.
-- [ ] Add abuse/fraud detection for repeated check-ins, suspicious review
-  patterns, and coordinated likes/comments.
-- [ ] Add deployment smoke tests for `/api/health`, `/api/discover`,
-  `/api/stripe/webhook`, `/api/auth/me`, and SPA fallback routes.
+- [ ] Run live deployment smoke tests for `/api/health`, `/api/discover`,
+  `/api/stripe/webhook`, `/api/auth/me`, Supabase Realtime, and SPA fallback
+  routes against the target environment.
 - [ ] Apply and smoke-test the PostGIS, review-summary, and deal-status
   migrations in the target Supabase project.
 - [ ] Link or pull Vercel project settings locally, then rerun `npx vercel build`.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,3 +8,7 @@ VITE_RECAPTCHA_SITE_KEY=your-recaptcha-site-key
 
 # API URL (optional; defaults to /api in production and localhost:8000 in dev)
 VITE_API_URL=
+
+# Supabase Realtime (optional; enables live feed/comments/events updates)
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=

--- a/frontend/src/lib/supabaseRealtime.ts
+++ b/frontend/src/lib/supabaseRealtime.ts
@@ -1,0 +1,183 @@
+import { logger } from './logger'
+
+type RealtimeTable = 'activity_feed' | 'activity_comments' | 'owner_events'
+type RealtimeType = 'INSERT' | 'UPDATE' | 'DELETE'
+
+export type RealtimePostgresChange<T> = {
+  type: RealtimeType
+  table: RealtimeTable
+  record: T | null
+  old_record: Partial<T> | null
+}
+
+type SubscribeOptions<T> = {
+  table: RealtimeTable
+  filter?: string
+  onChange: (change: RealtimePostgresChange<T>) => void
+}
+
+type PhoenixMessage = {
+  topic: string
+  event: string
+  payload?: {
+    data?: {
+      type?: string
+      table?: string
+      record?: unknown
+      old_record?: unknown
+    }
+  } & Record<string, unknown>
+  ref?: string
+}
+
+const SUPABASE_URL = (import.meta.env.VITE_SUPABASE_URL || '').trim().replace(/\/$/, '')
+const SUPABASE_ANON_KEY = (import.meta.env.VITE_SUPABASE_ANON_KEY || '').trim()
+const HEARTBEAT_MS = 25_000
+const RECONNECT_BASE_MS = 1_000
+const RECONNECT_MAX_MS = 30_000
+const RECONNECT_MAX_ATTEMPTS = 10
+
+export function realtimeConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY && typeof WebSocket !== 'undefined')
+}
+
+export function subscribeToTable<T>({
+  table,
+  filter,
+  onChange,
+}: SubscribeOptions<T>): { unsubscribe: () => void } {
+  if (!realtimeConfigured()) {
+    return { unsubscribe: () => {} }
+  }
+
+  let socket: WebSocket | null = null
+  let heartbeatId: number | undefined
+  let reconnectId: number | undefined
+  let closed = false
+  let ref = 0
+  let reconnectAttempts = 0
+
+  const nextRef = () => String(++ref)
+  const topic = `realtime:public:${table}`
+
+  const send = (event: string, payload: Record<string, unknown>, targetTopic = topic) => {
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ topic: targetTopic, event, payload, ref: nextRef() }))
+    }
+  }
+
+  const clearTimers = () => {
+    if (heartbeatId) window.clearInterval(heartbeatId)
+    if (reconnectId) window.clearTimeout(reconnectId)
+    heartbeatId = undefined
+    reconnectId = undefined
+  }
+
+  const scheduleReconnect = () => {
+    if (closed || reconnectId || reconnectAttempts >= RECONNECT_MAX_ATTEMPTS) return
+    const jitter = Math.random() * 1_000
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts + jitter, RECONNECT_MAX_MS)
+    reconnectAttempts++
+    reconnectId = window.setTimeout(() => {
+      reconnectId = undefined
+      connect()
+    }, delay)
+  }
+
+  const connect = () => {
+    clearTimers()
+    const url = realtimeWebsocketUrl()
+    if (!url) return
+
+    socket = new WebSocket(url)
+    socket.onopen = () => {
+      reconnectAttempts = 0
+      send('phx_join', {
+        config: {
+          postgres_changes: [
+            {
+              event: '*',
+              schema: 'public',
+              table,
+              ...(filter ? { filter } : {}),
+            },
+          ],
+          broadcast: { self: false },
+          presence: { key: '' },
+        },
+      })
+      heartbeatId = window.setInterval(() => {
+        send('heartbeat', {}, 'phoenix')
+      }, HEARTBEAT_MS)
+    }
+
+    socket.onmessage = (event) => {
+      handleMessage<T>(event.data, table, onChange)
+    }
+
+    socket.onerror = (event) => {
+      logger.warn('Supabase realtime socket error', { table, event })
+    }
+
+    socket.onclose = () => {
+      clearTimers()
+      socket = null
+      scheduleReconnect()
+    }
+  }
+
+  connect()
+
+  return {
+    unsubscribe: () => {
+      closed = true
+      clearTimers()
+      if (socket?.readyState === WebSocket.OPEN) {
+        send('phx_leave', {})
+      }
+      socket?.close()
+      socket = null
+    },
+  }
+}
+
+function realtimeWebsocketUrl(): string | null {
+  try {
+    const url = new URL(SUPABASE_URL)
+    url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:'
+    url.pathname = '/realtime/v1/websocket'
+    url.search = new URLSearchParams({
+      apikey: SUPABASE_ANON_KEY,
+      vsn: '1.0.0',
+    }).toString()
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function handleMessage<T>(
+  raw: string,
+  expectedTable: RealtimeTable,
+  onChange: (change: RealtimePostgresChange<T>) => void
+) {
+  let message: PhoenixMessage
+  try {
+    message = JSON.parse(raw) as PhoenixMessage
+  } catch {
+    return
+  }
+
+  if (message.event !== 'postgres_changes') return
+
+  const data = message.payload?.data
+  if (!data || data.table !== expectedTable) return
+  if (data.type !== 'INSERT' && data.type !== 'UPDATE' && data.type !== 'DELETE') return
+
+  onChange({
+    type: data.type,
+    table: expectedTable,
+    record: (data.record ?? null) as T | null,
+    old_record: (data.old_record ?? null) as Partial<T> | null,
+  })
+}

--- a/frontend/src/pages/ActivityFeedPage.tsx
+++ b/frontend/src/pages/ActivityFeedPage.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import { api } from '../api'
 import { logger } from '@/lib/logger'
+import { subscribeToTable } from '@/lib/supabaseRealtime'
 import type { ActivityFeedItem, UserCredibility, CredibilityTier, ActivityComment } from '../types'
 import {
   MapPin, Star, Tag, Calendar, Award, TrendingUp,
@@ -128,6 +129,65 @@ export default function ActivityFeedPage() {
   useEffect(() => {
     loadFeed(1)
   }, [loadFeed])
+
+  useEffect(() => {
+    const feedSubscription = subscribeToTable<ActivityFeedItem>({
+      table: 'activity_feed',
+      onChange: ({ type, record, old_record }) => {
+        const id = record?.id || old_record?.id
+        if (!id) return
+
+        setFeedItems(prev => {
+          if (type === 'DELETE') return prev.filter(item => item.id !== id)
+          if (!record) return prev
+
+          const exists = prev.some(item => item.id === record.id)
+          if (type === 'INSERT' && !exists) return [record, ...prev]
+          if (!exists) return prev
+          return prev.map(item => item.id === record.id ? { ...item, ...record } : item)
+        })
+
+        if (user?.id && record?.liked_by) {
+          setLikedItems(prev => {
+            const next = new Set(prev)
+            if (record.liked_by?.includes(user.id)) next.add(record.id)
+            else next.delete(record.id)
+            return next
+          })
+        }
+      },
+    })
+
+    const commentSubscription = subscribeToTable<ActivityComment>({
+      table: 'activity_comments',
+      onChange: ({ type, record, old_record }) => {
+        const activityId = record?.activity_id || old_record?.activity_id
+        const commentId = record?.id || old_record?.id
+        if (!activityId || !commentId) return
+
+        setCommentsByItem(prev => {
+          const current = prev[activityId]
+          if (!current) return prev
+
+          if (type === 'DELETE') {
+            return { ...prev, [activityId]: current.filter(comment => comment.id !== commentId) }
+          }
+
+          if (!record) return prev
+          const exists = current.some(comment => comment.id === record.id)
+          const nextComments = exists
+            ? current.map(comment => comment.id === record.id ? { ...comment, ...record } : comment)
+            : [...current, record]
+          return { ...prev, [activityId]: nextComments }
+        })
+      },
+    })
+
+    return () => {
+      feedSubscription.unsubscribe()
+      commentSubscription.unsubscribe()
+    }
+  }, [user?.id])
 
   const loadComments = useCallback(async (activityId: string) => {
     try {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { Link } from 'react-router-dom'
 import { api } from '../api'
 import { logger } from '@/lib/logger'
+import { subscribeToTable } from '@/lib/supabaseRealtime'
 import type { Business, Deal, Review, Subscription, BusinessActivityStatus, BusinessClaim, OwnerEvent } from '../types'
 import {
   Store, Star, Tag, TrendingUp, Plus,
@@ -43,6 +44,7 @@ export default function DashboardPage() {
   const [eventError, setEventError] = useState('')
   const [isCreatingEvent, setIsCreatingEvent] = useState(false)
   const [loading, setLoading] = useState(true)
+  const selectedBizId = selectedBiz?.id || selectedBiz?._id || ''
 
   const selectBusiness = useCallback(async (biz: Business) => {
     setSelectedBiz(biz)
@@ -91,6 +93,31 @@ export default function DashboardPage() {
     if (!isAuthenticated || user?.role !== 'business_owner') return
     loadDashboard()
   }, [isAuthenticated, user, loadDashboard])
+
+  useEffect(() => {
+    if (!selectedBizId || !isAuthenticated || user?.role !== 'business_owner') return
+
+    const subscription = subscribeToTable<OwnerEvent>({
+      table: 'owner_events',
+      filter: `business_id=eq.${selectedBizId}`,
+      onChange: ({ type, record, old_record }) => {
+        const id = record?.id || old_record?.id
+        if (!id) return
+
+        setOwnerEvents(current => {
+          if (type === 'DELETE') return current.filter(event => event.id !== id)
+          if (!record) return current
+
+          const exists = current.some(event => event.id === record.id)
+          if (type === 'INSERT' && !exists) return [record, ...current]
+          if (!exists) return current
+          return current.map(event => event.id === record.id ? { ...event, ...record } : event)
+        })
+      },
+    })
+
+    return () => subscription.unsubscribe()
+  }, [isAuthenticated, selectedBizId, user?.role])
 
   const handleCreateEvent = async () => {
     if (!selectedBiz) return
@@ -171,7 +198,7 @@ export default function DashboardPage() {
     )
   }
 
-  const bizId = selectedBiz?.id || selectedBiz?._id || ''
+  const bizId = selectedBizId
 
   return (
     <div className="min-h-[60vh] py-8 px-4">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -360,6 +360,7 @@ export interface ActivityFeedItem {
 /** A comment on an activity feed item. */
 export interface ActivityComment {
   id: string;
+  activity_id?: string;
   user_id: string;
   user_name: string;
   profile_picture?: string;

--- a/vercel.json
+++ b/vercel.json
@@ -37,7 +37,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://accounts.google.com https://www.google.com https://www.gstatic.com; frame-src https://accounts.google.com https://www.google.com; form-action 'self'; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://accounts.google.com https://www.google.com https://www.gstatic.com https://*.supabase.co wss://*.supabase.co; frame-src https://accounts.google.com https://www.google.com; form-action 'self'; frame-ancestors 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- **Rate limit key spoof fixed** — removed `cf-connecting-ip` from trusted IP sources. This app runs on Vercel (not Cloudflare), so that header is never set or stripped by infrastructure and was fully spoofable by clients, bypassing the 20 req/min brute-force cap on `/auth/login` and `/auth/register`. `x-real-ip` is now the first-priority source; a regression test asserts `cf-connecting-ip` is ignored.
- **Deprecated XSS header corrected** — `X-XSS-Protection` changed from `1; mode=block` to `0` (OWASP current guidance; the legacy browser auditor it activates has caused CVEs and is superseded by the existing CSP + `nosniff` headers).
- **Realtime reconnect backoff** — replaced the unbounded fixed-3s reconnect loop in `supabaseRealtime.ts` with exponential backoff (1s base, 2× per attempt, ±1s jitter, 30s max) capped at 10 attempts. Counter resets to 0 on successful open.
- **Supabase realtime live-updates** — new `supabaseRealtime.ts` utility + integration in `ActivityFeedPage` (feed + comments) and `DashboardPage` (owner events). Subscriptions use the anon key against RLS-gated tables (`activity_feed`, `activity_comments`, `owner_events` — all already public-read; no new data exposure).
- **Backend hardening** — route-level improvements across deals, reviews, saved, claims, subscriptions, activity, businesses; pagination cursor helpers; Stripe webhook idempotency guards; LVS invariant tests.
- **Migration docs fixed** — `202605200003_deal_status_consistency.sql` added to CLAUDE.md's authoritative migrations list (was absent, would be skipped on fresh deploys).

## Test plan

- [ ] `cargo test` — 52 tests pass (up from 51; new `cf_connecting_ip_is_not_trusted_without_cloudflare` test included)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [ ] `npm run build` — clean, no type errors
- [ ] `npm run lint` — clean
- [ ] Verify login/register rate limiting still triggers after 20 requests from the same IP
- [ ] Verify realtime feed updates appear without page refresh on `ActivityFeedPage`
- [ ] Verify `DashboardPage` owner events update live when business is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)