### PR TITLE
fix(security): block role escalation, harden review updates, strip se…

### DIFF
--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -253,9 +253,10 @@ async fn ensure_auth_defaults(
 fn registration_role(role: Option<&UserRole>) -> Result<&'static str> {
     match role.unwrap_or(&UserRole::Customer) {
         UserRole::Customer => Ok("customer"),
-        UserRole::BusinessOwner => Ok("business_owner"),
-        UserRole::Admin => Err(AppError::Forbidden(
-            "Admin accounts cannot be self-registered".into(),
+        // Business-owner and admin roles cannot be self-assigned at registration;
+        // owner status is granted through the verified claim flow.
+        UserRole::BusinessOwner | UserRole::Admin => Err(AppError::Forbidden(
+            "This role cannot be self-registered".into(),
         )),
     }
 }

--- a/backend/src/routes/reviews.rs
+++ b/backend/src/routes/reviews.rs
@@ -209,7 +209,11 @@ async fn update_review(
     let updated = state
         .db
         .supabase
-        .update_json("reviews", &[eq("id", &id)], Value::Object(body))
+        .update_json(
+            "reviews",
+            &[eq("id", &id), eq("user_id", &auth_user.id)],
+            Value::Object(body),
+        )
         .await?;
     let row = updated
         .into_iter()

--- a/backend/src/routes/users.rs
+++ b/backend/src/routes/users.rs
@@ -140,16 +140,19 @@ fn user_json(user: &AuthUserRecord, include_private: bool) -> Value {
         .user_metadata
         .get("preferences")
         .unwrap_or(&Value::Null);
+    let role = metadata_str(&user.app_metadata, "role").unwrap_or("customer");
+    // Never expose admin status on public profiles — show as customer instead.
+    let public_role = if role == "admin" { "customer" } else { role };
+
     let mut value = json!({
         "id": user.id,
         "_id": user.id,
         "name": name,
         "full_name": full_name,
-        "role": metadata_str(&user.app_metadata, "role").unwrap_or("customer"),
+        "role": if include_private { role } else { public_role },
         "profile_picture": metadata_str(&user.user_metadata, "profile_picture"),
         "about_me": metadata_str(&user.user_metadata, "about_me"),
         "created_at": user.created_at,
-        "subscription_tier": metadata_str(&user.app_metadata, "subscription_tier").unwrap_or("FREE"),
         "preferences": preferences,
         "preferred_categories": preferences.get("preferred_categories").cloned().unwrap_or(Value::Null),
         "preferred_vibes": preferences.get("preferred_vibes").cloned().unwrap_or(Value::Null),
@@ -161,6 +164,8 @@ fn user_json(user: &AuthUserRecord, include_private: bool) -> Value {
 
     if include_private {
         value["email"] = json!(email);
+        value["subscription_tier"] =
+            json!(metadata_str(&user.app_metadata, "subscription_tier").unwrap_or("FREE"));
     }
 
     value


### PR DESCRIPTION
…nsitive public profile fields

- Reject business_owner/admin self-registration; role must be granted via claim flow
- Add user_id filter to review UPDATE query as DB-layer defense-in-depth
- Remove subscription_tier from public user profiles
- Mask admin role as customer in public profiles to prevent admin enumeration